### PR TITLE
Fix parsing DWORD keys from registry on Windows

### DIFF
--- a/lib/GLPI/Agent/Config.pm
+++ b/lib/GLPI/Agent/Config.pm
@@ -185,14 +185,16 @@ sub _loadFromRegistry {
     foreach my $rawKey (keys %$settings) {
         next unless $rawKey =~ /^\/(\S+)/;
         my $key = lc($1);
-        my $val = $settings->{$rawKey};
-        # Remove the quotes
-        $val =~ s/\s+$//;
-        $val =~ s/^'(.*)'$/$1/;
-        $val =~ s/^"(.*)"$/$1/;
-        
-        if ($val =~ m/^0x([0-9]+)$/) {
-            $val = hex($settings->{$rawKey});
+        my ($val, $type) = $settings->GetValue($key);
+
+        if ($type == Win32::TieRegistry::REG_SZ()) {
+            $val =~ s/\s+$//;
+            $val =~ s/^'(.*)'$/$1/;
+            $val =~ s/^"(.*)"$/$1/;
+        }
+
+        if ($type == Win32::TieRegistry::REG_DWORD()) {
+            $val = hex($val);
         }
 
         if (exists $default->{$key}) {

--- a/lib/GLPI/Agent/Config.pm
+++ b/lib/GLPI/Agent/Config.pm
@@ -190,6 +190,10 @@ sub _loadFromRegistry {
         $val =~ s/\s+$//;
         $val =~ s/^'(.*)'$/$1/;
         $val =~ s/^"(.*)"$/$1/;
+        
+        if ($val =~ m/^0x([0-9]+)$/) {
+            $val = hex($settings->{$rawKey});
+        }
 
         if (exists $default->{$key}) {
             $self->{$key} = $val;


### PR DESCRIPTION
If the key is not in REG_SZ but REG_DWORD, value like "0x0000" are not read as a 0