### PR TITLE
Correct Ssh.pm for private key usage

### DIFF
--- a/lib/GLPI/Agent/Task/RemoteInventory/Remote/Ssh.pm
+++ b/lib/GLPI/Agent/Task/RemoteInventory/Remote/Ssh.pm
@@ -89,7 +89,7 @@ sub _connect {
         foreach my $file (glob($ENV{HOME}."/.ssh/*")) {
             next unless getFirstMatch(
                 file    => $file,
-                pattern => /^-----BEGIN (.*) PRIVATE KEY-----$/,
+                pattern => qr/^-----BEGIN (.*) PRIVATE KEY-----\n/,
             );
             my ($key) = $file =~ m{/([^/]+)$};
             $self->{_private_keys}->{$key} = $file;


### PR DESCRIPTION
If no password is entered during add of remote host, glpi-agent will try to use private key available in .ssh folder of current user (in services mode, it will use root user).
But currently that not work due to error on pattern line : 
 - First, need to add "qr" to identify a Regex (See perl Regexp Quote-Like Operators )
 - Second, to search only first line and at end of first line, we must remove "$" and add "\n" at end of pattern