### PR TITLE
fix: screen's edid fetch from /sys/devices

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Generic/Screen.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Screen.pm
@@ -10,6 +10,7 @@ use MIME::Base64;
 use UNIVERSAL::require;
 
 use File::Find;
+use File::Basename;
 use GLPI::Agent::Tools;
 use GLPI::Agent::Tools::Screen;
 
@@ -195,7 +196,7 @@ sub _getScreensFromUnix {
                 {
                     no_chdir => 1,
                     wanted   => sub {
-                        return unless $_ eq 'edid';
+                        return unless basename($_) eq 'edid';
                         return unless has_file($File::Find::name);
                         my $edid = getAllLines(file => $File::Find::name);
                         push @screens, { edid => $edid } if $edid;

--- a/lib/GLPI/Agent/Task/Inventory/Generic/Screen.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Screen.pm
@@ -197,8 +197,8 @@ sub _getScreensFromUnix {
                     no_chdir => 1,
                     wanted   => sub {
                         return unless basename($_) eq 'edid';
-                        return unless has_file($File::Find::name);
-                        my $edid = getAllLines(file => $File::Find::name);
+                        return unless has_file($_);
+                        my $edid = getAllLines(file => $_);
                         push @screens, { edid => $edid } if $edid;
                     },
                 },


### PR DESCRIPTION
The wanted filename was matched against the absolute path : the comparison never evaluate to TRUE.
Now the filename is matched against the file's basename.