### PR TITLE
pci videos detect: always enabled, include 3d controller

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -46,6 +46,7 @@ Jérome Lebas: Solaris patches
 Jon Clarke: patch
 Julien Safar: ArchLinux support
 Kevin Roy: patches
+Khad: patch
 Lucas Masse: Solaris Patches
 Ludovic Hutin: patch
 Marcin Kowalski: LXD support
@@ -59,7 +60,7 @@ Nicolas Eisen: patches
 Nicolas Richard: patches and bug reports
 Olivier Andreotti: AIX, Solaris patches
 Olivier Mengué
-Olivier Roussy: minor patches 
+Olivier Roussy: minor patches
 Pablo Nicola: AIX testing samples
 Philippe Camelio: AIX testing samples
 Philippe Libat: patchs and Xen support

--- a/lib/GLPI/Agent/Task/Inventory/Generic/PCI/Videos.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/PCI/Videos.pm
@@ -13,10 +13,7 @@ use GLPI::Agent::Tools::Generic;
 use constant    category    => "video";
 
 sub isEnabled {
-    # both windows and linux have dedicated modules
-    return
-        OSNAME ne 'MSWin32' &&
-        OSNAME ne 'linux';
+    return 1;
 }
 
 sub doInventory {
@@ -37,7 +34,8 @@ sub _getVideos {
     my @videos;
 
     foreach my $device (getPCIDevices(@_)) {
-        next unless $device->{NAME} =~ /graphics|vga|video|display/i;
+        next unless $device->{NAME} =~ /graphics|vga|video|display|3D controller/i;
+
         push @videos, {
             CHIPSET => $device->{NAME},
             NAME    => $device->{MANUFACTURER},


### PR DESCRIPTION
example names:
```
VGA compatible controller Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics]
3D controller NVIDIA Corporation TU117M [GeForce GTX 1650 Mobile / Max-Q]
```
