### PR TITLE
bugfix: ip from iproute2 underreports interfaces

### DIFF
--- a/resources/generic/ifconfig/linux-el8
+++ b/resources/generic/ifconfig/linux-el8
@@ -1,0 +1,58 @@
+docker0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 172.17.0.1  netmask 255.255.0.0  broadcast 172.17.255.255
+        ether 02:42:0c:d5:0f:d7  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        ether e4:11:5b:ed:36:0c  txqueuelen 1000  (Ethernet)
+        RX packets 27681443338  bytes 7773253411021 (7.0 TiB)
+        RX errors 9434  dropped 51838  overruns 0  frame 9434
+        TX packets 34788825065  bytes 26406512352943 (24.0 TiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth1: flags=4098<BROADCAST,MULTICAST>  mtu 1500
+        ether e4:11:5b:ed:36:38  txqueuelen 1000  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth2: flags=4098<BROADCAST,MULTICAST>  mtu 1500
+        ether e4:11:5b:ed:36:0e  txqueuelen 1000  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth3: flags=4098<BROADCAST,MULTICAST>  mtu 1500
+        ether e4:11:5b:ed:36:3a  txqueuelen 1000  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth0:srv: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 10.10.220.100  netmask 255.255.255.255  broadcast 0.0.0.0
+        ether e4:11:5b:ed:36:0c  txqueuelen 1000  (Ethernet)
+
+lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+        inet 127.0.0.1  netmask 255.0.0.0
+        inet6 ::1  prefixlen 128  scopeid 0x10<host>
+        loop  txqueuelen 1000  (Local Loopback)
+        RX packets 137902154908  bytes 41129565562314 (37.4 TiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 137902154908  bytes 41129565562314 (37.4 TiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+macvlan0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 10.10.220.101  netmask 255.255.255.0  broadcast 10.10.220.255
+        inet6 fe80::260f:e9bb:60de:58f4  prefixlen 64  scopeid 0x20<link>
+        ether 4e:05:62:03:69:e7  txqueuelen 1000  (Ethernet)
+        RX packets 25567695356  bytes 8625506639624 (7.8 TiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 23083998443  bytes 25613000107345 (23.2 TiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+

--- a/resources/linux/ip/ip_addr-el8
+++ b/resources/linux/ip/ip_addr-el8
@@ -1,0 +1,26 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether e4:11:5b:ed:36:0c brd ff:ff:ff:ff:ff:ff
+    inet 10.10.220.100/32 scope global eth0:srv
+       valid_lft forever preferred_lft forever
+3: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
+    link/ether e4:11:5b:ed:36:0e brd ff:ff:ff:ff:ff:ff
+4: eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
+    link/ether e4:11:5b:ed:36:38 brd ff:ff:ff:ff:ff:ff
+5: eth3: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
+    link/ether e4:11:5b:ed:36:3a brd ff:ff:ff:ff:ff:ff
+6: macvlan0@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+    link/ether 4e:05:62:03:69:e7 brd ff:ff:ff:ff:ff:ff
+    inet 10.10.220.101/24 brd 10.10.220.255 scope global dynamic noprefixroute macvlan0
+       valid_lft 76222sec preferred_lft 76222sec
+    inet6 fe80::260f:e9bb:60de:58f4/64 scope link noprefixroute 
+       valid_lft forever preferred_lft forever
+7: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+    link/ether 02:42:0c:d5:0f:d7 brd ff:ff:ff:ff:ff:ff
+    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
+       valid_lft forever preferred_lft forever

--- a/t/agent/tools/linux.t
+++ b/t/agent/tools/linux.t
@@ -1132,7 +1132,7 @@ my %ipaddrshow_tests = (
             STATUS      => 'Down',
             MACADDR     => 'e4:11:5b:ed:36:38',
         },
-		{
+        {
             DESCRIPTION => 'eth3',
             STATUS      => 'Down',
             MACADDR     => 'e4:11:5b:ed:36:3a',

--- a/t/agent/tools/linux.t
+++ b/t/agent/tools/linux.t
@@ -786,6 +786,62 @@ my %ifconfig_tests = (
             IPADDRESS6  => 'fe80::223:aeff:fe8c:33b6',
             IPADDRESS   => '10.1.65.145'
         }
+    ],
+    'linux-el8' => [
+        {
+            DESCRIPTION => 'docker0',
+            IPADDRESS   => '172.17.0.1',
+            IPMASK      => '255.255.0.0',
+            MACADDR     => '02:42:0c:d5:0f:d7',
+            STATUS      => 'Up',
+            TYPE        => 'ethernet',
+        },
+        {
+            DESCRIPTION => 'eth0',
+            MACADDR     => 'e4:11:5b:ed:36:0c',
+            STATUS      => 'Up',
+            TYPE        => 'ethernet'
+        },
+        {
+            DESCRIPTION => 'eth1',
+            TYPE        => 'ethernet',
+            STATUS      => 'Down',
+            MACADDR     => 'e4:11:5b:ed:36:38'
+        },
+        {
+            DESCRIPTION => 'eth2',
+            MACADDR     => 'e4:11:5b:ed:36:0e',
+            STATUS      => 'Down',
+            TYPE        => 'ethernet',
+        },
+		{
+            DESCRIPTION => 'eth3',
+            STATUS      => 'Down',
+            TYPE        => 'ethernet',
+            MACADDR     => 'e4:11:5b:ed:36:3a'
+        },
+        {
+            DESCRIPTION => 'eth0:srv',
+            IPADDRESS   => '10.10.220.100',
+            IPMASK      => '255.255.255.255',
+            MACADDR     => 'e4:11:5b:ed:36:0c',
+            STATUS      => 'Up',
+            TYPE        => 'ethernet',
+        },
+        {
+            DESCRIPTION => 'lo',
+            IPADDRESS6  => '::1',
+            STATUS      => 'Up',
+        },
+        {
+            DESCRIPTION => 'macvlan0',
+            IPADDRESS   => '10.10.220.101',
+            IPADDRESS6  => 'fe80::260f:e9bb:60de:58f4',
+            IPMASK      => '255.255.255.0',
+            MACADDR     => '4e:05:62:03:69:e7',
+            STATUS      => 'Up',
+            TYPE        => 'ethernet',
+        }
     ]
 );
 
@@ -1034,8 +1090,83 @@ my %ipaddrshow_tests = (
             DESCRIPTION => 'br0',
             STATUS      => 'Up',
             MACADDR     => 'aa:4b:c2:02:31:15'
-        }
+        },
+        {
+            DESCRIPTION => 'eth0',
+            MACADDR     => 'f0:1f:af:0f:a4:0c',
+            STATUS      => 'Up',
+        },
     ],
+    'ip_addr-el8' => [
+        {
+            DESCRIPTION => 'lo',
+            MACADDR     => '00:00:00:00:00:00',
+            STATUS      => 'Up',
+            IPADDRESS   => '127.0.0.1',
+            IPSUBNET    => '127.0.0.0',
+            IPMASK      => '255.0.0.0',
+        },
+        {
+            DESCRIPTION => 'lo',
+            MACADDR     => '00:00:00:00:00:00',
+            STATUS      => 'Up',
+            IPADDRESS6  => '::1',
+            IPSUBNET6   => '::',
+            IPMASK6     => 'fff0::',
+        },
+        {
+            DESCRIPTION => 'eth0:srv',
+            IPADDRESS   => '10.10.220.100',
+            IPSUBNET    => '10.10.220.100',
+            IPMASK      => '255.255.255.255',
+            MACADDR     => 'e4:11:5b:ed:36:0c',
+            STATUS      => 'Up',
+        },
+        {
+            DESCRIPTION => 'eth2',
+            STATUS      => 'Down',
+            MACADDR     => 'e4:11:5b:ed:36:0e',
+        },
+        {
+            DESCRIPTION => 'eth1',
+            STATUS      => 'Down',
+            MACADDR     => 'e4:11:5b:ed:36:38',
+        },
+		{
+            DESCRIPTION => 'eth3',
+            STATUS      => 'Down',
+            MACADDR     => 'e4:11:5b:ed:36:3a',
+        },
+        {
+            DESCRIPTION => 'macvlan0',
+            IPADDRESS   => '10.10.220.101',
+            IPSUBNET    => '10.10.220.0',
+            IPMASK      => '255.255.255.0',
+            MACADDR     => '4e:05:62:03:69:e7',
+            STATUS      => 'Up',
+        },
+        {
+            DESCRIPTION => 'macvlan0@eth0',
+            IPADDRESS6  => 'fe80::260f:e9bb:60de:58f4',
+            IPSUBNET6   => 'fe80::',
+            IPMASK6     => 'ffff:ffff:ffff:ffff::',
+            MACADDR     => '4e:05:62:03:69:e7',
+            STATUS      => 'Up',
+        },
+        {
+            DESCRIPTION => 'docker0',
+            IPADDRESS   => '172.17.0.1',
+            IPMASK      => '255.255.0.0',
+            IPSUBNET    => '172.17.0.0',
+            MACADDR     => '02:42:0c:d5:0f:d7',
+            STATUS      => 'Up',
+        },
+        {
+            DESCRIPTION => 'eth0',
+            MACADDR     => 'e4:11:5b:ed:36:0c',
+            STATUS      => 'Up',
+        },
+    ]
 );
 
 plan tests =>

--- a/t/agent/tools/linux.t
+++ b/t/agent/tools/linux.t
@@ -814,7 +814,7 @@ my %ifconfig_tests = (
             STATUS      => 'Down',
             TYPE        => 'ethernet',
         },
-		{
+        {
             DESCRIPTION => 'eth3',
             STATUS      => 'Down',
             TYPE        => 'ethernet',


### PR DESCRIPTION
`ip` and `ifconfig` provide different number of interfaces. Whenever a real/physical interface doesn't have an IP while an alias interface does, this real interface is masked by the alias. See the test fixtures, specifically eth0 and eth0:srv interfaces.