### PR TITLE
feat: Update VBS with expected features

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,6 +50,10 @@ packaging:
 * fix #446: Always add Sys::Hostname dependency to rpm packaging
 * fix #493: Add support for CONFIG=reset option for MSI Installer
 
+contrib:
+* fix #429: Permit MSI package installation from current folder
+* fix #505: [Idea] Improve VBS deployment with a check if installed correctly or retry
+
 1.5 Wed, 21 Jun 2023
 
 core:


### PR DESCRIPTION
Permit MSI package installation from current folder:
 - It supports now empty or `.` path as `SetupLocation`

Improve VBS deployment with a check if installed correctly or retry:
 - Firstly and between retries, the script check MsiServer service is available to not fail because of any other running MSI installation, this check expires at maximum after 2 minutes
 - On MsiServer service availability, the script tries to install the agent.
 - If it fails because of another MSI installation was concurrently started, it waits 30 seconds and retry. The script makes max 3 attempts.
 - If it fails on an unknown error, the script reports the error number in verbose mode and exit.

The MsiServer service availability check algorithm is:
 - Check if the service is stopped: it mean the service is available
 - Otherwise, tries to stop the service:
   - if it stops, it means it just become available
   - if the stop fails, it means the service is busy installing any MSI package