### PR TITLE
fqdn fix

### DIFF
--- a/lib/GLPI/Agent/Tools/Hostname.pm
+++ b/lib/GLPI/Agent/Tools/Hostname.pm
@@ -46,8 +46,11 @@ sub getHostname {
 
 sub _getHostnameUnix {
 
-    Sys::Hostname->require();
-    return Sys::Hostname::hostname();
+    Net::Domain->require();
+    my $fqdn = Net::Domain::hostfqdn();
+    $fqdn =~ s/\.$//;
+
+    return $fqdn;
 }
 
 sub _getHostnameWindows {

--- a/lib/GLPI/Agent/Tools/Hostname.pm
+++ b/lib/GLPI/Agent/Tools/Hostname.pm
@@ -48,7 +48,7 @@ sub _getHostnameUnix {
 
     Net::Domain->require();
     my $fqdn = Net::Domain::hostfqdn();
-    $fqdn =~ s/\.$//;
+    $fqdn =~ s/\.$//;  # the module may return a trailing dot
 
     return $fqdn;
 }


### PR DESCRIPTION
Sys::Hostname::hostname returns a short name, thus the fix.