### PR TITLE
Feature: fqdn value for assetname support option

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,13 @@ Revision history for GLPI agent
 
 inventory:
 * PR #531: Add SentinelOne Antivirus support on Linux, thanks to @MarcSamD
+* Feature: Update support assetname-support as option for agent on most unix
+  if 1 (the default), the short hostname is used as asset name
+  if 2, the as-is hostname (can be fqdn) is used as asset name
+  if 3, the fqdn hostname is used as asset name
+  this feature does not apply on MacOS or Windows
+  this feature now works for remote ssh and for option 3, it requires perl installed
+  on targeted computer and perl mode enabled on defined remote.
 
 netdiscovery/netinventory:
 * Enhanced Toshiba printers support

--- a/Changes
+++ b/Changes
@@ -11,6 +11,8 @@ inventory:
   this feature does not apply on MacOS or Windows
   this feature now works for remote ssh and for option 3, it requires perl installed
   on targeted computer and perl mode enabled on defined remote.
+* Feature: Make assetname-support option also works to compute agent deviceid when
+  unknown
 
 netdiscovery/netinventory:
 * Enhanced Toshiba printers support

--- a/lib/GLPI/Agent.pm
+++ b/lib/GLPI/Agent.pm
@@ -583,7 +583,15 @@ sub _handlePersistentState {
 
     if (!$self->{deviceid} && !$data->{deviceid}) {
         # compute an unique agent identifier, based on host name and current time
-        my $hostname = getHostname();
+        my %config = ();
+        if ($self->{config}->{'assetname-support'}) {
+            if ($self->{config}->{'assetname-support'} == 1) {
+                $config{short} = 1;
+            } elsif ($self->{config}->{'assetname-support'} == 3) {
+                $config{fqdn} = 1;
+            }
+        }
+        my $hostname = getHostname(%config);
 
         my ($year, $month , $day, $hour, $min, $sec) =
             (localtime (time))[5, 4, 3, 2, 1, 0];

--- a/lib/GLPI/Agent/Task/Inventory/Generic/Domains.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Domains.pm
@@ -46,7 +46,7 @@ sub doInventory {
 
     # attempt to deduce the actual domain from the host name
     # and fallback on the domain search list
-    my $hostname = getHostname();
+    my $hostname = getHostname(fqdn => 1);
     my $pos = index $hostname, '.';
 
     if ($pos > 0) {

--- a/lib/GLPI/Agent/Task/Inventory/Generic/Hostname.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Hostname.pm
@@ -27,6 +27,8 @@ sub doInventory {
     my $hostname;
     if ($assetname_support == 2) {
         $hostname = getHostname();
+    } elsif ($assetname_support == 3) {
+        $hostname = getHostname(fqdn => 1);
     } else {
         $hostname = getHostname(short => 1);
     }


### PR DESCRIPTION
As pointed out in Changes file:
```
* Feature: Update support assetname-support as option for agent on most unix
  if 1 (the default), the short hostname is used as asset name
  if 2, the as-is hostname (can be fqdn) is used as asset name
  if 3, the fqdn hostname is used as asset name
  this feature does not apply on MacOS or Windows
  this feature now works for remote ssh and for option 3, it requires perl installed
  on targeted computer and perl mode enabled on defined remote.
* Feature: Make assetname-support option also works to compute agent deviceid when
  unknown
```

IMHO this is a better answer than forcing every one to use fqdn as proposed in #535.

It also makes the option working for remoteinventory task.