### PR TITLE
Bugfix: Memory size value for Vmware Virtual Machine

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Generic/Dmidecode/Memory.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Dmidecode/Memory.pm
@@ -26,8 +26,8 @@ sub isEnabled {
 sub doInventory {
     my (%params) = @_;
 
-    my $inventory      = $params{inventory};
-    my $logger         = $params{logger};
+    my $inventory = $params{inventory};
+    my $logger    = $params{logger};
 
     my $memories = _getMemories(logger => $logger);
 

--- a/lib/GLPI/Agent/Task/Inventory/Generic/Dmidecode/Memory.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Dmidecode/Memory.pm
@@ -28,7 +28,6 @@ sub doInventory {
 
     my $inventory      = $params{inventory};
     my $logger         = $params{logger};
-    my @physmemsystems = ('Physical', 'VMware');
 
     my $memories = _getMemories(logger => $logger);
 
@@ -37,7 +36,7 @@ sub doInventory {
     # If only one component is defined and we are under a vmsystem, we can update
     # component capacity to real found size. This permits to support memory size updates.
     my $vmsystem = $inventory->getHardware('VMSYSTEM');
-    if ($vmsystem && ! grep ( /^$vmsystem$/, @physmemsystems)) {
+    if ($vmsystem && $vmsystem !~ /^(Physical|VMware)$/) {
         my @components = grep { exists $_->{CAPACITY} } @$memories;
         if ( @components == 1) {
             my $real_memory = $inventory->getHardware('MEMORY');

--- a/lib/GLPI/Agent/Task/Inventory/Generic/Dmidecode/Memory.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Dmidecode/Memory.pm
@@ -26,8 +26,9 @@ sub isEnabled {
 sub doInventory {
     my (%params) = @_;
 
-    my $inventory = $params{inventory};
-    my $logger    = $params{logger};
+    my $inventory      = $params{inventory};
+    my $logger         = $params{logger};
+    my @physmemsystems = ('Physical', 'VMware');
 
     my $memories = _getMemories(logger => $logger);
 
@@ -36,7 +37,7 @@ sub doInventory {
     # If only one component is defined and we are under a vmsystem, we can update
     # component capacity to real found size. This permits to support memory size updates.
     my $vmsystem = $inventory->getHardware('VMSYSTEM');
-    if ($vmsystem && $vmsystem ne 'Physical') {
+    if ($vmsystem && ! grep ( /^$vmsystem$/, @physmemsystems)) {
         my @components = grep { exists $_->{CAPACITY} } @$memories;
         if ( @components == 1) {
             my $real_memory = $inventory->getHardware('MEMORY');


### PR DESCRIPTION
Dmidecode slot memory size value overrided by /proc/meminfo value when there is only one memory slot for a Vmware virtual machine. It should not.
This commit should fix bug #571 I have created.
I haven't tested if this bug is also present other Virtual systems like Xen, VirtualBox...