### PR TITLE
Update Getopt.pm

### DIFF
--- a/contrib/unix/installer/Getopt.pm
+++ b/contrib/unix/installer/Getopt.pm
@@ -182,7 +182,7 @@ glpi-agent-linux-installer [options]
                                      - "snap": don't install but extract snap package
     --runnow                       run agent tasks on installation (false)
     --type=INSTALL_TYPE            select type of installation (typical)
-                                     - "typical" to only install inventory task
+                                     - "typical" to only install Computer Inventory and Remote Inventory tasks
                                      - "network" to install glpi-agent and network related tasks
                                      - "all" to install all tasks
                                      - or tasks to install in a comma-separated list

--- a/contrib/unix/installer/Getopt.pm
+++ b/contrib/unix/installer/Getopt.pm
@@ -182,7 +182,7 @@ glpi-agent-linux-installer [options]
                                      - "snap": don't install but extract snap package
     --runnow                       run agent tasks on installation (false)
     --type=INSTALL_TYPE            select type of installation (typical)
-                                     - "typical" to only install Computer Inventory and Remote Inventory tasks
+                                     - "typical" to only install computer inventory and remote inventory tasks
                                      - "network" to install glpi-agent and network related tasks
                                      - "all" to install all tasks
                                      - or tasks to install in a comma-separated list


### PR DESCRIPTION
Clarify that a "typical" installation only installs the "Computer Inventory" and "Remote Inventory" tasks. (It does not include the "ESX Remote Inventory" or "Network Inventory (SNMP)" tasks.