### PR TITLE
Improve Aruba SSID detection

### DIFF
--- a/lib/GLPI/Agent/SNMP/MibSupport/Aruba.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/Aruba.pm
@@ -118,14 +118,18 @@ sub run {
             $device->{PORTS}->{PORT}->{$port}->{IFALIAS} = $ifDescr
                 unless empty($ifDescr);
             # Replaces the radio port name with its respective <SSID>
-            $device->{PORTS}->{PORT}->{$port}->{IFNAME} = getCanonicalString($aiWlanESSIDValues->{$index});
+            my $ifName = getCanonicalString($aiWlanESSIDValues->{$index});
+            unless (empty($ifName)) {
+                # radio0 and radio1 are the network interfaces for the 5GHz and 2.4GHz radios respectively
+                if ($ifDescr =~ m/^radio0/) {
+                    $ifName .= " (5GHz)";
+                } elsif ($ifDescr =~ m/^radio1/) {
+                    $ifName .= " (2.4GHz)";
+                }
 
-            # radio0 and radio1 are the network interfaces for the 5GHz and 2.4GHz radios respectively
-            if ($ifDescr =~ m/^radio(0)/) {
-                $device->{PORTS}->{PORT}->{$port}->{IFNAME} .= " (5GHz)";
-            } elsif ($ifDescr =~ m/^radio(1)/) {
-                $device->{PORTS}->{PORT}->{$port}->{IFNAME} .= " (2.4GHz)";
+                $device->{PORTS}->{PORT}->{$port}->{IFNAME} = $ifName;
             }
+            last;
         }
     }
 }

--- a/lib/GLPI/Agent/SNMP/MibSupport/Aruba.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/Aruba.pm
@@ -112,10 +112,11 @@ sub run {
             my $ifMacAddress = $device->{PORTS}->{PORT}->{$port}->{MAC};
             next unless defined($ifMacAddress) && $ifMacAddress eq $wlanMacAddress;
 
-            my $ifDescr = $device->{PORTS}->{PORT}->{$port}->{IFDESCR};
+            my $ifDescr = $device->{PORTS}->{PORT}->{$port}->{IFDESCR} // "";
 
             # Defines the port alias with the name of the radio (e.g. radioX_ssid_idY)
-            $device->{PORTS}->{PORT}->{$port}->{IFALIAS} = $ifDescr;
+            $device->{PORTS}->{PORT}->{$port}->{IFALIAS} = $ifDescr
+                unless empty($ifDescr);
             # Replaces the radio port name with its respective <SSID>
             $device->{PORTS}->{PORT}->{$port}->{IFNAME} = getCanonicalString($aiWlanESSIDValues->{$index});
 

--- a/lib/GLPI/Agent/SNMP/MibSupport/Aruba.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/Aruba.pm
@@ -106,7 +106,8 @@ sub run {
 
     foreach my $index (keys(%$aiWlanMACAddressValues)) {
         # Get WLAN BSSID (e.g. XX:XX:XX:XX:XX:XX)
-        my $wlanMacAddress = getCanonicalMacAddress($aiWlanMACAddressValues->{$index});
+        my $wlanMacAddress = getCanonicalMacAddress($aiWlanMACAddressValues->{$index})
+            or next;
 
         foreach my $port (keys(%$ports)) {
             my $ifMacAddress = $device->{PORTS}->{PORT}->{$port}->{MAC};


### PR DESCRIPTION
Similar to #657 but for Aruba IAP devices, replacing ifName (e.g. ``radioX_ssid_idY``) by it's respective SSID name.
Please notice that for this enhancement works as expected it's need to mark ``188`` iftype importable as discussed  in https://github.com/glpi-project/glpi/issues/16981

XML GLPI Agent inventory for Aruba AP:
Before applying this fix: [networkequipment_0_8.xml.txt](https://github.com/glpi-project/glpi/files/15076588/networkequipment_0_8.xml.txt)
After applying this fix: [networkequipment_0_8_PR658.xml.txt](https://github.com/glpi-project/glpi-agent/files/15083485/networkequipment_0_8_PR658.xml.txt)

snmpwalk file for Aruba AP:
[arubaiap.walk.txt](https://github.com/glpi-project/glpi/files/15083474/arubaiap.walk.txt)