### PR TITLE
Fix LLDP device import on HPE/3Com Comware devices

### DIFF
--- a/lib/GLPI/Agent/Tools/Hardware.pm
+++ b/lib/GLPI/Agent/Tools/Hardware.pm
@@ -1273,6 +1273,12 @@ sub _getLLDPInfo {
             my $mac = alt2canonical($portId) || getCanonicalMacAddress($lldpRemPortId->{$suffix});
             # Add mac only if different than SYSMAC
             push @{$connection->{MAC}}, $mac if $mac && $mac ne $connection->{SYSMAC};
+            if(empty($connection->{MAC})) {
+                my ($extracted) = $suffix =~ /^\d+\.(.*)\.\d+$/;
+                if ($extracted =~ /^\d+$/) {
+                    $connection->{IFNUMBER} = $extracted;
+                }
+            }
         } elsif ($PortIdSubtype eq '1' || $PortIdSubtype eq '5' || $PortIdSubtype eq '7') { # Interface alias or interface name or "local", "local" should be the remote IFNUMBER
             if ($portId =~ /^\d+$/) {
                 $connection->{IFNUMBER} = $portId;

--- a/lib/GLPI/Agent/Tools/Hardware.pm
+++ b/lib/GLPI/Agent/Tools/Hardware.pm
@@ -11,8 +11,6 @@ use GLPI::Agent::Tools::Network;
 use GLPI::Agent::Tools::SNMP;
 use GLPI::Agent::SNMP::Device;
 
-use Net::IP qw(ip_is_ipv4);
-
 our @EXPORT = qw(
     getDeviceInfo
     getDeviceFullInfo
@@ -1306,21 +1304,6 @@ sub _getLLDPInfo {
                                               $port2interface->{$id};
 
         $results->{$interface_id} = $connection;
-
-        # Associate IP address with device
-        # RFC1213-MIB::atPhysAddress.54.1.192.168.0.128 = Hex-STRING: 00 0B 82 54 42 84
-        my $atPhysAddresses = $snmp->walk('.1.3.6.1.2.1.3.1.1.2') || {}; # atPhysAddress
-        if ($atPhysAddresses) {
-            foreach my $index (keys(%{$atPhysAddresses})) {
-                my $atPhysAddress = getCanonicalMacAddress($atPhysAddresses->{$index});
-                if ($atPhysAddress eq $connection->{SYSMAC}) {
-                    # Extract device IPv4 from index
-                    my $atLogicAddress = _getElement($index, -4) . '.' . _getElement($index, -3) . '.' . _getElement($index, -2) . '.'. _getElement($index, -1);
-                    push @{$connection->{IP}}, $atLogicAddress if Net::IP::ip_is_ipv4($atLogicAddress);
-                    last;
-                }
-            }
-        }
     }
 
     return $results;

--- a/lib/GLPI/Agent/Tools/Hardware.pm
+++ b/lib/GLPI/Agent/Tools/Hardware.pm
@@ -1274,7 +1274,7 @@ sub _getLLDPInfo {
             # Add mac only if different than SYSMAC
             push @{$connection->{MAC}}, $mac if $mac && $mac ne $connection->{SYSMAC};
             if(empty($connection->{MAC})) {
-                my ($extracted) = $suffix =~ /^\d+\.(.*)\.\d+$/;
+                my ($extracted) = _getElement($suffix, -2);
                 if ($extracted =~ /^\d+$/) {
                     $connection->{IFNUMBER} = $extracted;
                 }


### PR DESCRIPTION
I connected an IP phone LLDP capable in my 3Com 2952 (my Comware 5 homelab switch) connected to GigabitEthernet 1/0/7 seems to set https://github.com/glpi-project/glpi-agent/blob/develop/lib/GLPI/Agent/Tools/Hardware.pm#L1251-L1252 as "3". I added some Logger.debug after it to figure out other values that ``_getLLDPInfo()`` was returning and obtained the following:

```
[debug] #1, sysdescr: GXP1450 1.0.8.6
[debug] #1, PortId:
[debug] #1, PortIdSubtype: 3
[debug] #1, mac: 00:0b:82:54:42:84
[debug] #1, suffix: 78275931.7.1
```

Note that ``PortId`` is empty, and it falls into https://github.com/glpi-project/glpi-agent/blob/develop/lib/GLPI/Agent/Tools/Hardware.pm#L1272 because it's **PortIdSubtype** is equal to ``3``, but **$connection->{MAC}** isn't set on switch inventory file as can be seen below:

```
<PORT>
          <CONNECTIONS>
            <CDP>1</CDP>
            <CONNECTION>
              <IFDESCR>eth0</IFDESCR>
              <SYSDESCR>GXP1450 1.0.8.6</SYSDESCR>
              <SYSMAC>00:0b:82:54:42:84</SYSMAC>
              <SYSNAME>gxp1450_000b82544284</SYSNAME>
            </CONNECTION>
          </CONNECTIONS>
          <IFALIAS>GigabitEthernet1/0/7 Interface</IFALIAS>
          <IFDESCR>GigabitEthernet1/0/7</IFDESCR>
          <IFINERRORS>0</IFINERRORS>
          <IFINOCTETS>81054268</IFINOCTETS>
          <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
          <IFLASTCHANGE>9 days, 01:24:29.11</IFLASTCHANGE>
          <IFMTU>10240</IFMTU>
          <IFNAME>GigabitEthernet1/0/7</IFNAME>
          <IFNUMBER>7</IFNUMBER>
          <IFOUTERRORS>0</IFOUTERRORS>
          <IFOUTOCTETS>382000856</IFOUTOCTETS>
          <IFPORTDUPLEX>3</IFPORTDUPLEX>
          <IFSPEED>100000000</IFSPEED>
          <IFSTATUS>1</IFSTATUS>
          <IFTYPE>117</IFTYPE>
          <MAC>20:fd:f1:4f:ad:28</MAC>
          <TRUNK>0</TRUNK>
          <VLANS>
            <VLAN>
              <NAME>VLAN 0001</NAME>
              <NUMBER>1</NUMBER>
              <TAGGED>0</TAGGED>
            </VLAN>
          </VLANS>
        </PORT>
```

I believe that **PortIdSubtype** should expect a MAC address, but even modifying manually the switch inventory file to add the GE 1/0/7 MAC port inside the Connection (``<MAC>20:fd:f1:4f:ad:28</MAC>``), my IP phone simply isn't shown on GLPI, just that the port is "Up".

So I decided to manually add the Port number inside the Connection (``<IFNUMBER>7</IFNUMBER>``), but it still wasn't working.

I had to add both (``<MAC>20:fd:f1:4f:ad:28</MAC>`` and ``<IFNUMBER>7</IFNUMBER>``) and it simply reported my IP phone as expected:

![image](https://github.com/user-attachments/assets/ec7de711-5b0f-48c3-893c-dd9190c87e24)

Here's the relevant ``snmpwalk`` output:

**$ChassisIdSubType**:

```
C:\Program Files\GLPI-Agent>snmpwalk -v 2c -c public 192.168.0.1 .1.0.8802.1.1.2.1.4.1.1.4
iso.0.8802.1.1.2.1.4.1.1.4.78275931.7.1 = INTEGER: 4
```

**$lldpRemChassisId**:

```
C:\Program Files\GLPI-Agent>snmpwalk -v 2c -c public 192.168.0.1 .1.0.8802.1.1.2.1.4.1.1.5
iso.0.8802.1.1.2.1.4.1.1.5.78275931.7.1 = Hex-STRING: 00 0B 82 54 42 84
```

**$lldpRemPortIdSubtype**:

```
C:\Program Files\GLPI-Agent>snmpwalk -v 2c -c public 192.168.0.1 .1.0.8802.1.1.2.1.4.1.1.6
iso.0.8802.1.1.2.1.4.1.1.6.78275931.7.1 = INTEGER: 3
```

**$lldpRemPortId**:

```
C:\Program Files\GLPI-Agent>snmpwalk -v 2c -c public 192.168.0.1 .1.0.8802.1.1.2.1.4.1.1.7
iso.0.8802.1.1.2.1.4.1.1.7.78275931.7.1 = Hex-STRING: 00 0B 82 54 42 84
```

**$lldpRemPortDesc**:

```
C:\Program Files\GLPI-Agent>snmpwalk -v 2c -c public 192.168.0.1 .1.0.8802.1.1.2.1.4.1.1.8
iso.0.8802.1.1.2.1.4.1.1.8.78275931.7.1 = STRING: "eth0"
```

**$lldpRemSysName**:

```
C:\Program Files\GLPI-Agent>snmpwalk -v 2c -c public 192.168.0.1 .1.0.8802.1.1.2.1.4.1.1.9
iso.0.8802.1.1.2.1.4.1.1.9.78275931.7.1 = STRING: "gxp1450_000b82544284"
```

**$lldpRemSysDesc**:

```
C:\Program Files\GLPI-Agent>snmpwalk -v 2c -c public 192.168.0.1 .1.0.8802.1.1.2.1.4.1.1.10
iso.0.8802.1.1.2.1.4.1.1.10.78275931.7.1 = STRING: "GXP1450 1.0.8.6"
```

Here's the full SNMPWalk file:

[2952-walk.txt](https://github.com/user-attachments/files/16185523/2952-walk.txt)

Inventory file BEFORE this fix:

[2952-grandstream.ocs.txt](https://github.com/user-attachments/files/16185663/2952-grandstream.ocs.txt)

Inventory file AFTER this fix:

[2952-grandstream-debug.ocs.txt](https://github.com/user-attachments/files/16185662/2952-grandstream-debug.ocs.txt)