### PR TITLE
Prevent certificates overwriting during export

### DIFF
--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -632,8 +632,9 @@ sub _KeyChain_or_KeyStore_Export {
             $logger->debug2("Changing to '$certdir' temporary folder");
             chdir $certdir;
 
-            while (my ($i, $command) = each @certCommands) {
-                my $storeDirname = "$i";
+            foreach my $command (@certCommands) {
+                my ($kind, $store) = $command =~ /-Split( -\w+)? -Store (\w+)$/;
+                my $storeDirname = $kind && $kind =~ /^ -(\w+)$/ ? "$1-$store" : $store;
                 mkdir $storeDirname;
                 chdir $storeDirname;
                 getAllLines(
@@ -648,7 +649,7 @@ sub _KeyChain_or_KeyStore_Export {
             # Convert each crt file to base64 encoded cer file and concatenate in certchain file
             File::Glob->require();
             foreach my $certfile (File::Glob::bsd_glob("$certdir/*/*")) {
-                if ($certfile =~ m{/([^/]+\.crt)$}) {
+                if ($certfile =~ m{/([^/]+/[^/]+\.crt)$}) {
                     getAllLines(
                         command => "certutil -encode $1 temp.cer",
                         logger  => $logger

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -619,46 +619,35 @@ sub _KeyChain_or_KeyStore_Export {
         my $certdir = $tmpdir->dirname;
         $certdir =~ s{\\}{/}g;
         if (-d $certdir) {
+            my @certCommands = (
+			    "certutil -Silent -Split -Store CA",
+			    "certutil -Silent -Split -Store Root",
+			    "certutil -Silent -Split -Enterprise -Store CA",
+			    "certutil -Silent -Split -Enterprise -Store Root",
+			    "certutil -Silent -Split -GroupPolicy -Store CA",
+			    "certutil -Silent -Split -GroupPolicy -Store Root",
+			    "certutil -Silent -Split -User -Store CA",
+			    "certutil -Silent -Split -User -Store Root"
+            );
             $logger->debug2("Changing to '$certdir' temporary folder");
             chdir $certdir;
 
+            while (my ($i, $command) = each @certCommands) {
+                my $storeDirname = "$i";
+                mkdir $storeDirname;
+                chdir $storeDirname;
+                getAllLines(
+                    command => $command,
+                    logger  => $logger
+                );
+                chdir "..";
+            }
+
             # Export certificates from keystore as crt files
-            getAllLines(
-                command => "certutil -Silent -Split -Store CA",
-                logger  => $logger
-            );
-            getAllLines(
-                command => "certutil -Silent -Split -Store Root",
-                logger  => $logger
-            );
-            getAllLines(
-                command => "certutil -Silent -Split -Enterprise -Store CA",
-                logger  => $logger
-            );
-            getAllLines(
-                command => "certutil -Silent -Split -Enterprise -Store Root",
-                logger  => $logger
-            );
-            getAllLines(
-                command => "certutil -Silent -Split -GroupPolicy -Store CA",
-                logger  => $logger
-            );
-            getAllLines(
-                command => "certutil -Silent -Split -GroupPolicy -Store Root",
-                logger  => $logger
-            );
-            getAllLines(
-                command => "certutil -Silent -Split -User -Store CA",
-                logger  => $logger
-            );
-            getAllLines(
-                command => "certutil -Silent -Split -User -Store Root",
-                logger  => $logger
-            );
 
             # Convert each crt file to base64 encoded cer file and concatenate in certchain file
             File::Glob->require();
-            foreach my $certfile (File::Glob::bsd_glob("$certdir/*")) {
+            foreach my $certfile (File::Glob::bsd_glob("$certdir/*/*")) {
                 if ($certfile =~ m{/([^/]+\.crt)$}) {
                     getAllLines(
                         command => "certutil -encode $1 temp.cer",

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -620,14 +620,14 @@ sub _KeyChain_or_KeyStore_Export {
         $certdir =~ s{\\}{/}g;
         if (-d $certdir) {
             my @certCommands = (
-			    "certutil -Silent -Split -Store CA",
-			    "certutil -Silent -Split -Store Root",
-			    "certutil -Silent -Split -Enterprise -Store CA",
-			    "certutil -Silent -Split -Enterprise -Store Root",
-			    "certutil -Silent -Split -GroupPolicy -Store CA",
-			    "certutil -Silent -Split -GroupPolicy -Store Root",
-			    "certutil -Silent -Split -User -Store CA",
-			    "certutil -Silent -Split -User -Store Root"
+                "certutil -Silent -Split -Store CA",
+                "certutil -Silent -Split -Store Root",
+                "certutil -Silent -Split -Enterprise -Store CA",
+                "certutil -Silent -Split -Enterprise -Store Root",
+                "certutil -Silent -Split -GroupPolicy -Store CA",
+                "certutil -Silent -Split -GroupPolicy -Store Root",
+                "certutil -Silent -Split -User -Store CA",
+                "certutil -Silent -Split -User -Store Root"
             );
             $logger->debug2("Changing to '$certdir' temporary folder");
             chdir $certdir;


### PR DESCRIPTION
Certificates exported using `certutil` have a specific file name format, independent of their content. During exports from different stores, files are overwritten because they share the same names. I propose creating separate folders for each store. The conversion between certificate formats will search for files in nested folders.