### PR TITLE
Add SentinelOne EPP detection for macOS

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
+++ b/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
@@ -1,0 +1,71 @@
+package GLPI::Agent::Task::Inventory::MacOS::AntiVirus::SentinelOne;
+
+use strict;
+use warnings;
+
+use parent 'GLPI::Agent::Task::Inventory::Module';
+
+use GLPI::Agent::Tools;
+
+my $command = '/Library/Sentinel/sentinel-agent.bundle/Contents/MacOS/sentinelctl';
+
+sub isEnabled {
+    return canRun($command);
+}
+
+sub doInventory {
+    my (%params) = @_;
+
+    my $inventory = $params{inventory};
+    my $logger    = $params{logger};
+
+    my $antivirus = _getSentinelOne(logger => $logger);
+    if ($antivirus) {
+        $inventory->addEntry(
+            section => 'ANTIVIRUS',
+            entry   => $antivirus
+        );
+
+        $logger->debug2("Added $antivirus->{NAME} ".($antivirus->{VERSION}? " v$antivirus->{VERSION}":""))
+            if $logger;
+    }
+}
+
+sub _getSentinelOne {
+    my (%params) = @_;
+
+    my $antivirus = {
+        COMPANY     => "Sentinel Labs Inc.",
+        NAME        => "SentinelOne EPP",
+        ENABLED     => 0,
+    };
+
+    # Support file case for unittests if basefile is provided
+    if (empty($params{basefile})) {
+        $params{command} = "\"$command\" version";
+    } else {
+        $params{file} = $params{basefile}."-version";
+    }
+    my $version = getFirstMatch(
+        pattern => qr/^SentinelOne.* ([0-9.]+)$/,
+        %params
+    );
+    $antivirus->{VERSION} = $version if $version;
+
+    # Support file case for unittests if basefile is provided
+    if (empty($params{basefile})) {
+        $params{command} = "\"$command\" status";
+    } else {
+        $params{file} = $params{basefile}."-status";
+    }
+    my @status_lines = getAllLines(%params);
+    
+    my ($staticSignatures) = grep { /^\s.*staticSignatures:/i } @status_lines;
+    $antivirus->{BASE_VERSION} = $1
+        if $staticSignatures && $staticSignatures =~ /^\s.*staticSignatures:\s.*(\([0-9]+\))/i {
+            $antivirus->{ENABLED} = 1 if grep { /^\s.*Protection.*enabled$/i } @status_lines;
+        }
+    return $antivirus;
+}
+
+1;

--- a/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
+++ b/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
@@ -59,10 +59,6 @@ sub _getSentinelOne {
         $params{file} = $params{basefile}."-status";
     }
     my @lines = getAllLines(%params);
-    my $status = getFirstMatch(
-        pattern => qr/^\s.*Protection.*(enabled)$/i,
-        %params
-    );
     $antivirus->{ENABLED} = 1 if first { /^\s+Protection:\s+enabled$/i } @lines;
 
     return $antivirus;

--- a/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
+++ b/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
@@ -58,17 +58,16 @@ sub _getSentinelOne {
     } else {
         $params{file} = $params{basefile}."-status";
     }
-    my $base_version = getFirstMatch(
-        pattern => qr/^\s.*staticSignatures:\s.*(\([0-9]+\))/i,
-        %params
-    );
-    $antivirus->{BASE_VERSION} = $base_version if $base_version;
-
+    my @lines = getAllLines(%params);
+    my $base_version_line = first { /^\s+staticSignatures:\s/i } @lines;
+    $antivirus->{BASE_VERSION} = $1
+        if $base_version_line && $base_version_line =~ /^\s+staticSignatures:.*(\([0-9]+\))/i;
     my $status = getFirstMatch(
         pattern => qr/^\s.*Protection.*(enabled)$/i,
         %params
     );
-    $antivirus->{ENABLED} = 1 if $status && $status =~ /^enabled$/i; 
+    $antivirus->{ENABLED} = 1 if first { /^\s+Protection:\s+enabled$/i } @lines;
+
     
     return $antivirus;
 }

--- a/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
+++ b/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
@@ -65,7 +65,6 @@ sub _getSentinelOne {
     );
     $antivirus->{ENABLED} = 1 if first { /^\s+Protection:\s+enabled$/i } @lines;
 
-    
     return $antivirus;
 }
 

--- a/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
+++ b/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
@@ -58,13 +58,18 @@ sub _getSentinelOne {
     } else {
         $params{file} = $params{basefile}."-status";
     }
-    my @status_lines = getAllLines(%params);
+    my $base_version = getFirstMatch(
+        pattern => qr/^\s.*staticSignatures:\s.*(\([0-9]+\))/i,
+        %params
+    );
+    $antivirus->{BASE_VERSION} = $base_version if $base_version;
+
+    my $status = getFirstMatch(
+        pattern => qr/^\s.*Protection.*(enabled)$/i,
+        %params
+    );
+    $antivirus->{ENABLED} = 1 if $status && $status =~ /^enabled$/i; 
     
-    my ($staticSignatures) = grep { /^\s.*staticSignatures:/i } @status_lines;
-    $antivirus->{BASE_VERSION} = $1
-        if $staticSignatures && $staticSignatures =~ /^\s.*staticSignatures:\s.*(\([0-9]+\))/i {
-            $antivirus->{ENABLED} = 1 if grep { /^\s.*Protection.*enabled$/i } @status_lines;
-        }
     return $antivirus;
 }
 

--- a/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
+++ b/lib/GLPI/Agent/Task/Inventory/MacOS/AntiVirus/SentinelOne.pm
@@ -59,9 +59,6 @@ sub _getSentinelOne {
         $params{file} = $params{basefile}."-status";
     }
     my @lines = getAllLines(%params);
-    my $base_version_line = first { /^\s+staticSignatures:\s/i } @lines;
-    $antivirus->{BASE_VERSION} = $1
-        if $base_version_line && $base_version_line =~ /^\s+staticSignatures:.*(\([0-9]+\))/i;
     my $status = getFirstMatch(
         pattern => qr/^\s.*Protection.*(enabled)$/i,
         %params

--- a/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-status
+++ b/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-status
@@ -1,5 +1,5 @@
 Agent
-   Version:                           23.4.1.7125
+   Version:                           24.1.2.7444
    ID:                                xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
    Install Date:                      16/04/2024, 16:22:18
    Missing Authorizations:

--- a/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-status
+++ b/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-status
@@ -2,7 +2,7 @@ Agent
    Version:                           23.4.1.7125
    ID:                                xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
    Install Date:                      16/04/2024, 16:22:18
-   Missing Authorizations:            
+   Missing Authorizations:
    ES Framework:                      started
    Agent Operational State:           enabled
    Remote Profiler:                   not running

--- a/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-status
+++ b/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-status
@@ -1,0 +1,75 @@
+Agent
+   Version:                           23.4.1.7125
+   ID:                                xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+   Install Date:                      16/04/2024, 16:22:18
+   Missing Authorizations:            
+   ES Framework:                      started
+   Agent Operational State:           enabled
+   Remote Profiler:                   not running
+   Agent Network Monitoring:          started
+   Network Extension:                 running
+   Network Extension Content Filter:  active
+   Ready:                             yes
+   Protection:                        enabled
+   Infected:                          no
+   Network Quarantine:                no
+   Compatible OS:                     compatible
+Command
+   Authentication:                    enabled
+Daemons
+   Services
+      Agent Helper:                   ready
+      Agent UI:                       ready
+      Cleaner:                        ready
+      Control Service:                ready
+      Framework:                      ready
+      Guard:                          ready
+      Helper Service:                 ready
+      Lib Hooks Service:              ready
+      Lib Logs Service:               ready
+      Shell:                          ready
+   Integrity
+      sentineld:                      ok
+      sentineld_guard:                ok
+      sentineld_helper:               ok
+      sentineld_shell:                not running
+      sentineld_updater:              not running
+Launchd
+   agent-helper:                      valid
+   agent-ui:                          valid
+   sentinel-extensions:               valid
+   sentineld:                         valid
+   sentineld-guard:                   valid
+   sentineld-helper:                  valid
+   sentineld-shell:                   valid
+Management
+   Server:                            https://***SRV***.sentinelone.net
+   Site Key:                          *****SITE_KEY******
+   Last Seen:                         25/07/2024, 16:09:55
+   Connected:                         yes
+Assets
+   agentCompatibility:                signed by SentinelOne - not indexed - versioned (120231220110307)
+   arbiter:                           signed by SentinelOne - not indexed - versioned (120231211081250)
+   blacklist:                         empty asset
+   blacklistAdd:                      signed by SentinelOne - not indexed - not versioned
+   blacklistBase:                     signed by SentinelOne - not indexed - not versioned
+   certExclusion:                     signed by SentinelOne - not indexed - not versioned
+   deviceControl:                     signed by SentinelOne - indexed - not versioned
+   devicesData:                       signed by SentinelOne - not indexed - versioned (120231220110307)
+   firewallControl:                   signed by SentinelOne - indexed - not versioned
+   globalData:                        signed by SentinelOne - not indexed - not versioned
+   locations:                         signed by SentinelOne - indexed - not versioned
+   mgmtConfig:                        signed by SentinelOne - not indexed - not versioned
+   networkQuarantineControlRules:     signed by SentinelOne - indexed - not versioned
+   offlinekey:                        signed by SentinelOne - not indexed - not versioned
+   pathExclusion:                     signed by SentinelOne - not indexed - not versioned
+   scopeDetails:                      empty asset
+   whitelist:                         empty asset
+   whitelistAdd:                      signed by SentinelOne - not indexed - not versioned
+   whitelistBase:                     signed by SentinelOne - not indexed - not versioned
+   whitelistExtended:                 signed by SentinelOne - not indexed - versioned (120231220110307)
+Global assets
+   dynamicEngine:                     signed by SentinelOne - not indexed - versioned (120231211083910) (Embedded asset)
+   signaturesWhitelist:               signed by SentinelOne - not indexed - versioned (120231220110307) (Embedded asset)
+   spawnerToolsIdentities:            signed by SentinelOne - not indexed - versioned (120231211083910) (Embedded asset)
+   staticSignatures:                  signed by SentinelOne - not indexed - versioned (120240430133940) - Command asset ID: 00000**ID**00000 - Applied at: 2024-07-18T04:34:32Z

--- a/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-version
+++ b/resources/macos/antivirus/sentinelone-epp-24.1.2.7444-version
@@ -1,0 +1,1 @@
+SentinelOne 24.1.2.7444


### PR DESCRIPTION
For now the agent report the Version,state of Protection and a value of staticSignatures in base_version.

Has  @g-bougard request ([here](https://github.com/glpi-project/glpi-agent/discussions/367)), I can't find any official and public documentation :-(

Adding 2 responses file from sentinelctl status and version in resources/macos/antivirus