### PR TITLE
Fix rustdesk id not detected when not installed in default location on Windows

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Generic/Remote_Mgmt/RustDesk.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Remote_Mgmt/RustDesk.pm
@@ -37,7 +37,23 @@ sub doInventory {
     # Add support for --get-id parameter available since RustDesk 1.2 as id becomes empty in conf
     # Only works starting with RustDesk v1.2.2
     unless (defined($RustDeskID) && length($RustDeskID)) {
-        my $command = OSNAME eq 'MSWin32' ? 'C:\Program Files\RustDesk\rustdesk.exe' : 'rustdesk';
+        my $command = 'rustdesk';
+        if(OSNAME eq 'MSWin32'){
+            my $Registry;
+            my $installLocation;
+            Win32::TieRegistry->require();
+            Win32::TieRegistry->import(
+                Delimiter   => '/',
+                ArrayValues => 0,
+                TiedRef     => \$Registry
+            );
+
+            my $key = $Registry->Open('LMachine/SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/RustDesk', { Access => Win32::TieRegistry::KEY_READ() });
+
+            if(defined($key)){ $installLocation = $key->GetValue('InstallLocation') . '\rustdesk.exe'; }
+
+            $command = (defined($installLocation) && length($installLocation)) ? $installLocation : 'C:\Program Files\RustDesk\rustdesk.exe';
+        }
         if (canRun($command)) {
             $command = '"'.$command.'"' if OSNAME eq 'MSWin32';
             my $required = 1;

--- a/lib/GLPI/Agent/Task/Inventory/Generic/Remote_Mgmt/RustDesk.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Remote_Mgmt/RustDesk.pm
@@ -39,20 +39,12 @@ sub doInventory {
     unless (defined($RustDeskID) && length($RustDeskID)) {
         my $command = 'rustdesk';
         if(OSNAME eq 'MSWin32'){
-            my $Registry;
-            my $installLocation;
-            Win32::TieRegistry->require();
-            Win32::TieRegistry->import(
-                Delimiter   => '/',
-                ArrayValues => 0,
-                TiedRef     => \$Registry
+            GLPI::Agent::Tools::Win32->require();
+            my $installLocation = GLPI::Agent::Tools::Win32::getRegistryValue(
+                path   => "SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/RustDesk/InstallLocation",
+                logger => $logger
             );
-
-            my $key = $Registry->Open('LMachine/SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/RustDesk', { Access => Win32::TieRegistry::KEY_READ() });
-
-            if(defined($key)){ $installLocation = $key->GetValue('InstallLocation') . '\rustdesk.exe'; }
-
-            $command = (defined($installLocation) && length($installLocation)) ? $installLocation : 'C:\Program Files\RustDesk\rustdesk.exe';
+            $command = (empty($installLocation) ? 'C:\Program Files\RustDesk' : $installLocation) . '\rustdesk.exe';
         }
         if (canRun($command)) {
             $command = '"'.$command.'"' if OSNAME eq 'MSWin32';

--- a/lib/GLPI/Agent/Task/Inventory/Generic/Remote_Mgmt/RustDesk.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Remote_Mgmt/RustDesk.pm
@@ -41,7 +41,7 @@ sub doInventory {
         if(OSNAME eq 'MSWin32'){
             GLPI::Agent::Tools::Win32->require();
             my $installLocation = GLPI::Agent::Tools::Win32::getRegistryValue(
-                path   => "SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/RustDesk/InstallLocation",
+                path   => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Windows/CurrentVersion/Uninstall/RustDesk/InstallLocation",
                 logger => $logger
             );
             $command = (empty($installLocation) ? 'C:\Program Files\RustDesk' : $installLocation) . '\rustdesk.exe';


### PR DESCRIPTION
On Windows, when RustDesk is installed elsewhere than C:\Program Files\RustDesk, the agent cannot get the ID.
This fix should find the executable from the registry (Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RustDesk\InstallLocation) and thus be able to get the ID.