### PR TITLE
Allow to specify keychain path on macOS and remove Windows "User" keystore by default to ssl-keystore parameter

### DIFF
--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -612,7 +612,7 @@ sub _KeyChain_or_KeyStore_Export {
             }
         }
         getAllLines(
-            command => "security find-certificate -a -p $store >> '$file'",
+            command => "security find-certificate -a -p $store > '$file'",
             logger  => $logger
         );
         @certs = IO::Socket::SSL::Utils::PEM_file2certs($file)

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -603,8 +603,16 @@ sub _KeyChain_or_KeyStore_Export {
             SUFFIX      => ".pem",
         );
         my $file = $tmpfile->filename;
+        my store;
+        if ($self->{ssl_keystore})  {
+            foreach my $case (split(/,+/, $self->{ssl_keystore})) {
+                $case = trimWhitespace($case);
+                $store .= $case . " "
+                    if -e $case;
+            }
+        }
         getAllLines(
-            command => "security find-certificate -a -p > '$file'",
+            command => "security find-certificate -a -p $store >> '$file'",
             logger  => $logger
         );
         @certs = IO::Socket::SSL::Utils::PEM_file2certs($file)

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -603,8 +603,9 @@ sub _KeyChain_or_KeyStore_Export {
             SUFFIX      => ".pem",
         );
         my $file = $tmpfile->filename;
-        my $store;
+        my $store = "/Library/Keychains/System.keychain,/System/Library/Keychains/SystemRootCertificates.keychain";
         if ($self->{ssl_keystore})  {
+            $store = "";
             foreach my $case (split(/,+/, $self->{ssl_keystore})) {
                 $case = trimWhitespace($case);
                 $store .= $case . " "
@@ -637,9 +638,7 @@ sub _KeyChain_or_KeyStore_Export {
                 "certutil -Silent -Split -Enterprise -Store CA",
                 "certutil -Silent -Split -Enterprise -Store Root",
                 "certutil -Silent -Split -GroupPolicy -Store CA",
-                "certutil -Silent -Split -GroupPolicy -Store Root",
-                "certutil -Silent -Split -User -Store CA",
-                "certutil -Silent -Split -User -Store Root"
+                "certutil -Silent -Split -GroupPolicy -Store Root"
             );
         }
 

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -603,7 +603,7 @@ sub _KeyChain_or_KeyStore_Export {
             SUFFIX      => ".pem",
         );
         my $file = $tmpfile->filename;
-        my store;
+        my $store;
         if ($self->{ssl_keystore})  {
             foreach my $case (split(/,+/, $self->{ssl_keystore})) {
                 $case = trimWhitespace($case);


### PR DESCRIPTION
By default, only Windows agents can specify which keystore to load. This patch allows admins to set a filepath to a specific keychain file (e.g. "``/System/Library/Keychains/SystemRootCertificates.keychain``" to load system certificates only). By default, GLPI Agent export all keychains, which can lead that a third party process upload an untrusted certificate to the User store and exploit or commit a MitM attack of GLPI Agent traffic.