### PR TITLE
Improvements to ssl-keystore parameter

### DIFF
--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -600,13 +600,12 @@ sub _KeyChain_or_KeyStore_Export {
             SUFFIX      => ".pem",
         );
         my $file = $tmpfile->filename;
+        my $command = "security find-certificate -a -p";
+        $command .= " /System/Library/Keychains/SystemRootCertificates.keychain"
+            if $self->{ssl_keystore} =~ /^system-ssl-ca$/i;
         getAllLines(
-            command => "security find-certificate -a -p > '$file'",
-            logger  => $logger
-        );
-        getAllLines(
-            command => "security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> '$file'",
-            logger  => $logger
+             command => "$command > '$file'",
+             logger  => $logger
         );
         push @certs, IO::Socket::SSL::Utils::PEM_file2certs($file)
             if -s $file;

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -553,9 +553,6 @@ sub _setSSLOptions {
 sub _KeyChain_or_KeyStore_Export {
     my ($self) = @_;
 
-    # Only MacOSX and MSWin32 are supported
-    return unless $OSNAME =~ /^darwin|MSWin32$/;
-
     # But we don't need to extract anything if we still use an option to authenticate server certificate
     return if $self->{ca_cert_file} || $self->{ca_cert_dir} || (ref($self->{ssl_fingerprint}) eq 'ARRAY' && @{$self->{ssl_fingerprint}});
 
@@ -607,7 +604,11 @@ sub _KeyChain_or_KeyStore_Export {
             command => "security find-certificate -a -p > '$file'",
             logger  => $logger
         );
-        @certs = IO::Socket::SSL::Utils::PEM_file2certs($file)
+        getAllLines(
+            command => "security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> '$file'",
+            logger  => $logger
+        );
+        push @certs, IO::Socket::SSL::Utils::PEM_file2certs($file)
             if -s $file;
     } else {
         my @certCommands;

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -699,7 +699,7 @@ sub _KeyChain_or_KeyStore_Export {
     }
 
     # Include default CA file from Mozilla::CA if @certs is empty
-    if (!@certs && Mozilla::CA->require()) {
+    if ((!@certs || $self->{ssl_keystore} !~ /^system-ssl-ca$/i) && Mozilla::CA->require()) {
         my $cacert = Mozilla::CA::SSL_ca_file();
         push @certs, IO::Socket::SSL::Utils::PEM_file2certs($cacert)
             if -e $cacert;

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -692,6 +692,13 @@ sub _KeyChain_or_KeyStore_Export {
         }
     }
 
+    # Like Mozilla::CA, but using certs from /etc/ssl/certs
+    if ($OSNAME !~ /^darwin|MSWin32$/) {
+        my $cacert = "/etc/ssl/certs/ca-certificates.crt";
+        push @certs, IO::Socket::SSL::Utils::PEM_file2certs($cacert)
+            if -e $cacert;
+    }
+
     # Always include default CA file from Mozilla::CA
     if (Mozilla::CA->require()) {
         my $cacert = Mozilla::CA::SSL_ca_file();

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -694,9 +694,9 @@ sub _KeyChain_or_KeyStore_Export {
 
     # Like Mozilla::CA, but using certs from /etc/ssl/certs
     if ($OSNAME !~ /^darwin|MSWin32$/) {
-        my $cacert = "/etc/ssl/certs/ca-certificates.crt";
-        push @certs, IO::Socket::SSL::Utils::PEM_file2certs($cacert)
-            if -e $cacert;
+        my $sslcacert = "/etc/ssl/certs/ca-certificates.crt";
+        push @certs, IO::Socket::SSL::Utils::PEM_file2certs($sslcacert)
+            if -e $sslcacert;
     }
 
     # Always include default CA file from Mozilla::CA

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -699,7 +699,7 @@ sub _KeyChain_or_KeyStore_Export {
     }
 
     # Include default CA file from Mozilla::CA if @certs is empty
-    if ((!@certs || $self->{ssl_keystore} !~ /^system-ssl-ca$/i) && Mozilla::CA->require()) {
+    if ((!@certs || $OSNAME eq 'darwin' && $self->{ssl_keystore} !~ /^system-ssl-ca$/i) && Mozilla::CA->require()) {
         my $cacert = Mozilla::CA::SSL_ca_file();
         push @certs, IO::Socket::SSL::Utils::PEM_file2certs($cacert)
             if -e $cacert;

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -698,8 +698,8 @@ sub _KeyChain_or_KeyStore_Export {
             if -e $sslcacert;
     }
 
-    # Always include default CA file from Mozilla::CA
-    if (Mozilla::CA->require()) {
+    # Include default CA file from Mozilla::CA if @certs is empty
+    if (!@certs && Mozilla::CA->require()) {
         my $cacert = Mozilla::CA::SSL_ca_file();
         push @certs, IO::Socket::SSL::Utils::PEM_file2certs($cacert)
             if -e $cacert;


### PR DESCRIPTION
Add SystemRootCA for macOS and support other OSes to Mozilla:CA in ssl-keystore. This also adds support for using certs from /etc/ssl/certs (Unix/Linux systems like Debian).

As discussed in https://github.com/glpi-project/glpi-agent/pull/823, this PR adds the SystemRootCA for macOS and remove the ``ssl-keystore`` limitation on other systems as they could rely at least on Mozilla CA store.