### PR TITLE
Add 'tag' support for NetDiscovery/NetInventory tasks

### DIFF
--- a/lib/GLPI/Agent/Inventory.pm
+++ b/lib/GLPI/Agent/Inventory.pm
@@ -778,13 +778,24 @@ sub save {
 
         my $xml = GLPI::Agent::XML->new();
 
-        print $handle $xml->write({
-            REQUEST => {
-                CONTENT  => $self->getContent(),
-                DEVICEID => $self->getDeviceId(),
-                QUERY    => "INVENTORY",
-            }
-        });
+        if (defined($self->{config}->{tag}) && length($self->{config}->{tag})) {
+            print $handle $xml->write({
+                REQUEST => {
+                    CONTENT  => $self->getContent(),
+                    DEVICEID => $self->getDeviceId(),
+                    QUERY    => "INVENTORY",
+                }
+            });
+        } else {
+            print $handle $xml->write({
+                REQUEST => {
+                    CONTENT  => $self->getContent(),
+                    DEVICEID => $self->getDeviceId(),
+                    QUERY    => "INVENTORY",
+                    TAG      => $self->{config}->{'tag'},
+                }
+            });
+        }
 
     } elsif ($format eq 'html') {
 

--- a/lib/GLPI/Agent/Inventory.pm
+++ b/lib/GLPI/Agent/Inventory.pm
@@ -778,24 +778,18 @@ sub save {
 
         my $xml = GLPI::Agent::XML->new();
 
-        if (defined($self->{config}->{tag}) && length($self->{config}->{tag})) {
-            print $handle $xml->write({
-                REQUEST => {
-                    CONTENT  => $self->getContent(),
-                    DEVICEID => $self->getDeviceId(),
-                    QUERY    => "INVENTORY",
-                }
-            });
-        } else {
-            print $handle $xml->write({
-                REQUEST => {
-                    CONTENT  => $self->getContent(),
-                    DEVICEID => $self->getDeviceId(),
-                    QUERY    => "INVENTORY",
-                    TAG      => $self->{config}->{'tag'},
-                }
-            });
-        }
+        my %request_params = (REQUEST => {
+            CONTENT  => $self->getContent(),
+            DEVICEID => $self->getDeviceId(),
+            QUERY    => "INVENTORY",
+        });
+        my $config = $self->{config} || GLPI::Agent::Config->new();
+        $request_params{REQUEST}{TAG} = $config->{tag}
+            if defined($config->{tag}) && length($config->{tag});
+
+        print $handle $xml->write({
+            %request_params
+        });
 
     } elsif ($format eq 'html') {
 

--- a/lib/GLPI/Agent/Task/NetDiscovery.pm
+++ b/lib/GLPI/Agent/Task/NetDiscovery.pm
@@ -622,6 +622,7 @@ sub _sendMessage {
     my $message = GLPI::Agent::XML::Query->new(
         deviceid => $self->{deviceid} || 'foo',
         query    => 'NETDISCOVERY',
+		tag      => $self->{config}->{'tag'},
         content  => $content
     );
 

--- a/lib/GLPI/Agent/Task/NetDiscovery.pm
+++ b/lib/GLPI/Agent/Task/NetDiscovery.pm
@@ -619,12 +619,21 @@ sub _sendMessage {
     # Load GLPI::Agent::XML::Query as late as possible
     return unless GLPI::Agent::XML::Query->require();
 
-    my $message = GLPI::Agent::XML::Query->new(
-        deviceid => $self->{deviceid} || 'foo',
-        query    => 'NETDISCOVERY',
-        tag      => $self->{config}->{'tag'},
-        content  => $content
-    );
+    my $message;
+    if (defined($self->{config}->{tag}) && length($self->{config}->{tag})) {
+		$message = GLPI::Agent::XML::Query->new(
+        	deviceid => $self->{deviceid} || 'foo',
+        	query    => 'NETDISCOVERY',
+        	tag      => $self->{config}->{'tag'},
+        	content  => $content
+    	);
+    } else {
+		$message = GLPI::Agent::XML::Query->new(
+        	deviceid => $self->{deviceid} || 'foo',
+        	query    => 'NETDISCOVERY',
+        	content  => $content
+    	);
+    }
 
     if ($self->{target}->isType('local')) {
         my ($handle, $file, $ip);

--- a/lib/GLPI/Agent/Task/NetDiscovery.pm
+++ b/lib/GLPI/Agent/Task/NetDiscovery.pm
@@ -622,7 +622,7 @@ sub _sendMessage {
     my $message = GLPI::Agent::XML::Query->new(
         deviceid => $self->{deviceid} || 'foo',
         query    => 'NETDISCOVERY',
-		tag      => $self->{config}->{'tag'},
+        tag      => $self->{config}->{'tag'},
         content  => $content
     );
 

--- a/lib/GLPI/Agent/Task/NetDiscovery.pm
+++ b/lib/GLPI/Agent/Task/NetDiscovery.pm
@@ -621,18 +621,18 @@ sub _sendMessage {
 
     my $message;
     if (defined($self->{config}->{tag}) && length($self->{config}->{tag})) {
-		$message = GLPI::Agent::XML::Query->new(
-        	deviceid => $self->{deviceid} || 'foo',
-        	query    => 'NETDISCOVERY',
-        	tag      => $self->{config}->{'tag'},
-        	content  => $content
-    	);
+        $message = GLPI::Agent::XML::Query->new(
+            deviceid => $self->{deviceid} || 'foo',
+            query    => 'NETDISCOVERY',
+            tag      => $self->{config}->{'tag'},
+            content  => $content
+        );
     } else {
-		$message = GLPI::Agent::XML::Query->new(
-        	deviceid => $self->{deviceid} || 'foo',
-        	query    => 'NETDISCOVERY',
-        	content  => $content
-    	);
+        $message = GLPI::Agent::XML::Query->new(
+            deviceid => $self->{deviceid} || 'foo',
+            query    => 'NETDISCOVERY',
+            content  => $content
+        );
     }
 
     if ($self->{target}->isType('local')) {

--- a/lib/GLPI/Agent/Task/NetDiscovery.pm
+++ b/lib/GLPI/Agent/Task/NetDiscovery.pm
@@ -619,21 +619,16 @@ sub _sendMessage {
     # Load GLPI::Agent::XML::Query as late as possible
     return unless GLPI::Agent::XML::Query->require();
 
-    my $message;
-    if (defined($self->{config}->{tag}) && length($self->{config}->{tag})) {
-        $message = GLPI::Agent::XML::Query->new(
-            deviceid => $self->{deviceid} || 'foo',
-            query    => 'NETDISCOVERY',
-            tag      => $self->{config}->{'tag'},
-            content  => $content
-        );
-    } else {
-        $message = GLPI::Agent::XML::Query->new(
-            deviceid => $self->{deviceid} || 'foo',
-            query    => 'NETDISCOVERY',
-            content  => $content
-        );
-    }
+    my %message_params = (
+        deviceid => $self->{deviceid} || 'foo',
+        query    => 'NETDISCOVERY',
+        content  => $content
+    );
+    $message_params{tag} = $self->{config}->{'tag'}
+        if defined($self->{config}->{tag}) && length($self->{config}->{tag});
+    my $message = GLPI::Agent::XML::Query->new(
+        %message_params
+    );
 
     if ($self->{target}->isType('local')) {
         my ($handle, $file, $ip);

--- a/lib/GLPI/Agent/Task/NetDiscovery.pm
+++ b/lib/GLPI/Agent/Task/NetDiscovery.pm
@@ -626,6 +626,7 @@ sub _sendMessage {
     );
     $message_params{tag} = $self->{config}->{'tag'}
         if defined($self->{config}->{tag}) && length($self->{config}->{tag});
+
     my $message = GLPI::Agent::XML::Query->new(
         %message_params
     );

--- a/lib/GLPI/Agent/Task/NetInventory.pm
+++ b/lib/GLPI/Agent/Task/NetInventory.pm
@@ -348,12 +348,21 @@ sub _sendMessage {
     # Load GLPI::Agent::XML::Query as late as possible
     return unless GLPI::Agent::XML::Query->require();
 
-    my $message = GLPI::Agent::XML::Query->new(
-        deviceid => $self->{deviceid} || 'foo',
-        query    => 'SNMPQUERY',
-        tag      => $self->{config}->{'tag'},
-        content  => $content
-    );
+    my $message;
+    if (defined($self->{config}->{tag}) && length($self->{config}->{tag})) {
+        $message = GLPI::Agent::XML::Query->new(
+            deviceid => $self->{deviceid} || 'foo',
+            query    => 'SNMPQUERY',
+            tag      => $self->{config}->{'tag'},
+            content  => $content
+        );
+    } else {
+        $message = GLPI::Agent::XML::Query->new(
+            deviceid => $self->{deviceid} || 'foo',
+            query    => 'SNMPQUERY',
+            content  => $content
+        );
+    }
 
     if ($self->{target}->isType('local')) {
         my ($handle, $file);

--- a/lib/GLPI/Agent/Task/NetInventory.pm
+++ b/lib/GLPI/Agent/Task/NetInventory.pm
@@ -355,6 +355,7 @@ sub _sendMessage {
     );
     $message_params{tag} = $self->{config}->{'tag'}
         if defined($self->{config}->{tag}) && length($self->{config}->{tag});
+
     my $message = GLPI::Agent::XML::Query->new(
         %message_params
     );

--- a/lib/GLPI/Agent/Task/NetInventory.pm
+++ b/lib/GLPI/Agent/Task/NetInventory.pm
@@ -351,7 +351,7 @@ sub _sendMessage {
     my $message = GLPI::Agent::XML::Query->new(
         deviceid => $self->{deviceid} || 'foo',
         query    => 'SNMPQUERY',
-		tag      => $self->{config}->{'tag'},
+        tag      => $self->{config}->{'tag'},
         content  => $content
     );
 

--- a/lib/GLPI/Agent/Task/NetInventory.pm
+++ b/lib/GLPI/Agent/Task/NetInventory.pm
@@ -348,21 +348,16 @@ sub _sendMessage {
     # Load GLPI::Agent::XML::Query as late as possible
     return unless GLPI::Agent::XML::Query->require();
 
-    my $message;
-    if (defined($self->{config}->{tag}) && length($self->{config}->{tag})) {
-        $message = GLPI::Agent::XML::Query->new(
-            deviceid => $self->{deviceid} || 'foo',
-            query    => 'SNMPQUERY',
-            tag      => $self->{config}->{'tag'},
-            content  => $content
-        );
-    } else {
-        $message = GLPI::Agent::XML::Query->new(
-            deviceid => $self->{deviceid} || 'foo',
-            query    => 'SNMPQUERY',
-            content  => $content
-        );
-    }
+    my %message_params = (
+        deviceid => $self->{deviceid} || 'foo',
+        query    => 'SNMPQUERY',
+        content  => $content
+    );
+    $message_params{tag} = $self->{config}->{'tag'}
+        if defined($self->{config}->{tag}) && length($self->{config}->{tag});
+    my $message = GLPI::Agent::XML::Query->new(
+        %message_params
+    );
 
     if ($self->{target}->isType('local')) {
         my ($handle, $file);

--- a/lib/GLPI/Agent/Task/NetInventory.pm
+++ b/lib/GLPI/Agent/Task/NetInventory.pm
@@ -351,6 +351,7 @@ sub _sendMessage {
     my $message = GLPI::Agent::XML::Query->new(
         deviceid => $self->{deviceid} || 'foo',
         query    => 'SNMPQUERY',
+		tag      => $self->{config}->{'tag'},
         content  => $content
     );
 


### PR DESCRIPTION
Hello,
This commit adds the same Computer tag to NetDiscovery/NetInventory and ESX inventory tasks. This fix https://github.com/glpi-project/glpi-inventory-plugin/issues/504

A little background: I have a small IT company and I act more like a MSP for other small business. These clients doesn't have condition to keep a GLPI server on their own. I use an Entity for each client have access to their own assets and I was able to create a Entity rule (Administration > Rules > [Rules for assigning an item to an entity](https://glpi.example.com/front/ruleimportentity.php)) based on GLPI-Agent tag, but it was working only for Computer inventory, other devices (like SNMP switches and printers) was being assigned to the default Entity and I had to move them manually to the respective Entity. I couldn't find any attribute that I could use to differ the clients based only on the available Entity rules fields - I couldn't use the subnet/IP address because most clients have a 192.168.0.0/24 network so it wouldn't be reliable. As those tasks doesn't provide the TAG field, I decided to create this PR to be able to use the Computer tag to assign those devices to the correct Entity.

Here's the Entity rule I've created:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ac2788a2-ac0b-41fb-a732-a3e049b059a3" />

Here's a screenshot to prove it's working:

<img width="629" alt="image" src="https://github.com/user-attachments/assets/897db943-605d-4712-ae07-aea3f6cba2a5" />

Here's sample inventory files I've used to test the rule (a SNMP printer):

[esx_esxi01.xml.txt](https://github.com/user-attachments/files/18483544/esx_esxi01.xml.txt)
[netdiscovery_brother.xml.txt](https://github.com/user-attachments/files/18483545/netdiscovery_brother.xml.txt)
[netinventory_brother.xml.txt](https://github.com/user-attachments/files/18483546/netinventory_brother.xml.txt)

Note: For some reason, it works only when importing a non-existing device, if it already exists, it updates it's information but it doesn't change it's Entity. It seems that the Entity rules is applied only when the device is created on GLPI, but I'm not sure if it's a bug or an intended feature.
