### PR TITLE
Improve Brother SNMP printer inventory (ifType)

### DIFF
--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -101,7 +101,7 @@ sub updatePortIfType {
     foreach my $index (keys %{$brMultiIFType}) {
         foreach my $port (keys %{$ports}) {
             next unless defined($ports->{$port}->{IFNAME}) && defined($brMultiIFNodeType->{$index});
-            if ($ports->{$port}->{IFNAME} eq $brMultiIFNodeType->{$index}) {
+            if ($ports->{$port}->{IFNAME} eq getCanonicalString($brMultiIFNodeType->{$index})) {
                 # wirelesslan(2)
                 if (defined($brMultiIFType->{$index}) && isInteger($brMultiIFType->{$index}) && int($brMultiIFType->{$index}) == 2) {
                     # ieee80211(71)

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -93,7 +93,7 @@ sub getPortIfType {
     # Get list of device ports types (lan(1)/wirelesslan(2))
     my $brMultiIFType = $self->walk(brMultiIFType) || {};
 
-    # Get list of device ports names 
+    # Get list of device ports names
     my $brMultiIFNodeType = $self->walk(brMultiIFNodeType) || {};
 
     foreach my $index (keys %{$brMultiIFType}) {

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -81,7 +81,7 @@ sub getModel {
     return $model;
 }
 
-sub getPortIfType {
+sub updatePortIfType {
     my ($self) = @_;
 
     my $device = $self->device
@@ -128,7 +128,7 @@ sub run {
         $device->{PAGECOUNTERS}->{$counter} = $count;
     }
 
-    $self->getPortIfType();
+    $self->updatePortIfType();
 }
 
 1;

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -103,7 +103,7 @@ sub getPortIfType {
             next unless defined($ports->{$port}->{IFNAME}) && defined($brMultiIFNodeType->{$index});
             if ($ports->{$port}->{IFNAME} eq $brMultiIFNodeType->{$index}) {
                 # wirelesslan(2)
-                if (defined($brMultiIFType->{$index}) && $brMultiIFType->{$index} eq 2) {
+                if (defined($brMultiIFType->{$index}) && isInteger($brMultiIFType->{$index}) && int($brMultiIFType->{$index}) == 2) {
                     # ieee80211(71)
                     $ports->{$port}->{IFTYPE} = 71
                 }

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -98,7 +98,7 @@ sub getPortIfType {
 
     foreach my $index (keys %{$brMultiIFType}) {
         foreach my $port (keys %{$ports}) {
-            if ($ports->{$port}->{IFDESCR} eq $brMultiIFNodeType->{$index}) {
+            if ($ports->{$port}->{IFNAME} eq $brMultiIFNodeType->{$index}) {
                 # wirelesslan(2)
                 if (defined($brMultiIFType->{$index}) && $brMultiIFType->{$index} eq 2) {
                     # ieee80211(71)

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -95,7 +95,8 @@ sub getPortIfType {
         or return;
 
     # Get list of device ports names
-    my $brMultiIFNodeType = $self->walk(brMultiIFNodeType) || {};
+    my $brMultiIFNodeType = $self->walk(brMultiIFNodeType)
+        or return;
 
     foreach my $index (keys %{$brMultiIFType}) {
         foreach my $port (keys %{$ports}) {

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -100,6 +100,7 @@ sub getPortIfType {
 
     foreach my $index (keys %{$brMultiIFType}) {
         foreach my $port (keys %{$ports}) {
+            next unless defined($ports->{$port}->{IFNAME}) && defined($brMultiIFNodeType->{$index});
             if ($ports->{$port}->{IFNAME} eq $brMultiIFNodeType->{$index}) {
                 # wirelesslan(2)
                 if (defined($brMultiIFType->{$index}) && $brMultiIFType->{$index} eq 2) {

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -91,7 +91,8 @@ sub getPortIfType {
     my $ports = $device->{PORTS}->{PORT};
 
     # Get list of device ports types (lan(1)/wirelesslan(2))
-    my $brMultiIFType = $self->walk(brMultiIFType) || {};
+    my $brMultiIFType = $self->walk(brMultiIFType)
+        or return;
 
     # Get list of device ports names
     my $brMultiIFNodeType = $self->walk(brMultiIFNodeType) || {};

--- a/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
+++ b/lib/GLPI/Agent/SNMP/MibSupport/BrotherNetConfig.pm
@@ -19,6 +19,8 @@ use constant    printerinfomation   => net_peripheral . '.4.2.1.5.5' ;
 use constant    brInfoSerialNumber  => printerinfomation . '.1.0' ;
 use constant    brScanCountCounter  => printerinfomation . '.54.2.2.1.3.3';
 
+use constant    brpsWLanName        => brother . '.2.4.3.100.11.1.3';
+
 # Brother NetConfig
 use constant    brnetconfig => brother . '.2.4.3.1240' ;
 use constant    brconfig    => brnetconfig . '.1' ;
@@ -77,6 +79,40 @@ sub getModel {
     return $model;
 }
 
+sub getWlanPorts {
+    my ($self) = @_;
+
+    my $device = $self->device
+        or return;
+
+    # Get list of device ports
+    my %ports = %{$device->{PORTS}->{PORT}};  # Shallow copy
+    foreach my $key (keys %ports) {
+        $ports{$key} = {%{$ports{$key}}};  # Deep copy for one level deep hash
+    }
+    
+    foreach my $port (keys %ports) {
+        # Loopback or DOWN interfaces
+        if ($ports{$port}->{IFTYPE} == 24 || $ports{$port}->{IFTYPE} == 2) {
+            delete $ports{$port};
+        }
+    }
+    
+    # Only one interface remaining and actually connected to a WLAN network
+    my $brpsWLanName = $self->walk(brpsWLanName);
+    if (scalar(keys %ports) == 1 && $brpsWLanName) {
+        foreach my $port (keys %ports) {
+            # Replaces the port ifType from "Ethernet" to "WiFi" (71)
+            if ($ports{$port}->{IFTYPE} == 6 || $ports{$port}->{IFTYPE} == 7) {
+                # WLAN network name strlen is greather than zero
+                if (length((keys %{$brpsWLanName})[0]) gt 0) {
+                    $device->{PORTS}->{PORT}->{$port}->{IFTYPE} = 71;
+                }
+            };
+        }
+    }
+}
+
 sub run {
     my ($self) = @_;
 
@@ -92,6 +128,8 @@ sub run {
             or next;
         $device->{PAGECOUNTERS}->{$counter} = $count;
     }
+    
+    $self->getWlanPorts();
 }
 
 1;


### PR DESCRIPTION
This commit improves the inventory of network ports of Brother printers. I have a HL-1210W printer which reports it's ifType as "``iso88023Csmacd(7)``" (Ethernet) instead of "``ieee80211(71)``" (Wireless). I'd opened a bug report with Brother but it's a common issue with other models as Brother [QL-710W](https://gist.github.com/pklaus/6fa17bb13eddd74bcfb6). It happens because Brother uses https://mibs.observium.org/mib/BROTHER-MIB/#brMultiIFConfigureTable to determine interface type. This PR queries those values and change the port type accordingly.
I also would like to know if it's possible to set the Wi-Fi Network which the printer belongs through netinventory tasks, so I could use ``$brpsWLanName->{(keys %{$brpsWLanName})[0]}`` as seen in https://github.com/glpi-project/glpi-agent/commit/ae8828bbe12b747d0bcdd3019040383a6b4de057. The only solution I could found was renaming the interface name to reflect the Wi-Fi Network name, but if the interface name changes, the interface metrics history is "lost" (unassociated) since a new interface is created in GLPI.

Brother HL-1210W snmpwalk: [snmpwalk-brother.txt](https://github.com/user-attachments/files/18558155/snmpwalk-brother.txt)