### PR TITLE
Update install-deb.sh

### DIFF
--- a/contrib/unix/install-deb.sh
+++ b/contrib/unix/install-deb.sh
@@ -61,6 +61,7 @@ downloadurlesx=$BaseUrl\glpi-agent-task-esx_$version\_all.deb
 # Setup dependencies for Agent Core
 echo "Installing agent dependencies"
 {
+    apt update
     apt-get -y install dmidecode hwdata ucf hdparm
     apt-get -y install perl libuniversal-require-perl libwww-perl libparse-edid-perl
     apt-get -y install libproc-daemon-perl libfile-which-perl libhttp-daemon-perl
@@ -92,6 +93,7 @@ echo
 if $tasknetwork; then
     echo "network task is requested"
     echo "installing dependencies"
+    apt update
     apt -y install libnet-snmp-perl libcrypt-des-perl libnet-nbname-perl libdigest-hmac-perl >> GLPIAgentInstallation.log 2>/dev/null
     wget $downloadurlnetwork -q --show-progress
     dpkg -i glpi-agent-task-network_$version\_all.deb
@@ -106,6 +108,7 @@ echo
 if $taskdeploy; then
     echo "deploy task is requested"
     echo "installing dependencies"
+    apt update
     apt -y install libfile-copy-recursive-perl  libparallel-forkmanager-perl >> GLPIAgentInstallation.log 2>/dev/null
     wget $downloadurldeploy -q --show-progress
     dpkg -i glpi-agent-task-deploy_$version\_all.deb


### PR DESCRIPTION
add apt update before apt-get install
this is useful when using the script in e.g. ansible environments because the install script itself becomes independent from previous operations.