### PR TITLE
Do PROLOG and fallback to CONTACT if supported

### DIFF
--- a/lib/GLPI/Agent.pm
+++ b/lib/GLPI/Agent.pm
@@ -317,7 +317,7 @@ sub runTarget {
         if (ref($response) !~ /^GLPI::Agent::Protocol::/) {
             $self->{logger}->info("$target->{id} is not understanding GLPI Agent protocol");
             $target->isGlpiServer('false');
-            return $self->runTarget($target) unless $response->expiration;
+            return 0;
         }
 
         # Handle contact answer including expiration and/or errors
@@ -401,6 +401,8 @@ sub runTarget {
 
         # Keep contact response
         $contact_response = $response;
+    } else {
+        return $self->runTarget($target) unless $response->expiration;
     }
 
     # Used when running tasks after a taskrun event

--- a/lib/GLPI/Agent.pm
+++ b/lib/GLPI/Agent.pm
@@ -401,8 +401,6 @@ sub runTarget {
 
         # Keep contact response
         $contact_response = $response;
-    } else {
-        return $self->runTarget($target) unless $response->expiration;
     }
 
     # Used when running tasks after a taskrun event


### PR DESCRIPTION
Fix #851. I just flipped the "if" to do PROLOG first and fallback to CONTACT, this makes the Supported tasks be available on GLPI server before the inventory is made the first time.