### PR TITLE
Fix Proxmox/LXC memory conversion Lxc.pm

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Virtualization/Lxc.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Virtualization/Lxc.pm
@@ -102,10 +102,17 @@ sub  _getVirtualMachine {
                 if $val =~ $mac_address_pattern;
         }
 
-        if ($key eq 'lxc.cgroup.memory.limit_in_bytes' || $key eq 'lxc.cgroup2.memory.max') {
-            $val .= "b" if $val =~ /[KMGTP]$/i;
-            $container->{MEMORY} = getCanonicalSize($val, 1024);
-        }
+    	if ($key eq 'lxc.cgroup.memory.limit_in_bytes' || $key eq 'lxc.cgroup2.memory.max') {
+    	    if ($val =~ /[KMGTP]$/i) {
+    		$val .= "b";
+    		$container->{MEMORY} = getCanonicalSize($val, 1024);
+    	    } elsif ($val =~ /^\d+$/) {
+    		# Plain numeric value in bytes, convert to MB
+    		$container->{MEMORY} = int($val / (1024 * 1024));
+    	    } else {
+    		$container->{MEMORY} = getCanonicalSize($val, 1024);
+    	    }
+    	}	
 
         # Update container name in Proxmox environment
         if ($proxmox && ($key eq 'lxc.uts.name' || $key eq 'lxc.utsname')) {

--- a/lib/GLPI/Agent/Task/Inventory/Virtualization/Lxc.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Virtualization/Lxc.pm
@@ -102,17 +102,10 @@ sub  _getVirtualMachine {
                 if $val =~ $mac_address_pattern;
         }
 
-    	if ($key eq 'lxc.cgroup.memory.limit_in_bytes' || $key eq 'lxc.cgroup2.memory.max') {
-    	    if ($val =~ /[KMGTP]$/i) {
-    		$val .= "b";
-    		$container->{MEMORY} = getCanonicalSize($val, 1024);
-    	    } elsif ($val =~ /^\d+$/) {
-    		# Plain numeric value in bytes, convert to MB
-    		$container->{MEMORY} = int($val / (1024 * 1024));
-    	    } else {
-    		$container->{MEMORY} = getCanonicalSize($val, 1024);
-    	    }
-    	}	
+        if ($key eq 'lxc.cgroup.memory.limit_in_bytes' || $key eq 'lxc.cgroup2.memory.max') {
+            $val .= $val =~ /[KMGTP]$/i ? "b" : $val =~ /^\d+$/ ? "bytes" : "";
+            $container->{MEMORY} = getCanonicalSize($val, 1024);
+        }
 
         # Update container name in Proxmox environment
         if ($proxmox && ($key eq 'lxc.uts.name' || $key eq 'lxc.utsname')) {

--- a/t/tasks/inventory/virtualization/lxc.t
+++ b/t/tasks/inventory/virtualization/lxc.t
@@ -23,7 +23,7 @@ my %container_tests = (
             NAME    => 'config',
             VMTYPE  => 'lxc',
             STATUS  => STATUS_OFF,
-            MEMORY  => '2048000',
+            MEMORY  => '1',
             MAC     => '01:23:45:67:89:0a',
             VCPU    => 4
         }
@@ -55,7 +55,7 @@ my %container_tests = (
             VMTYPE  => 'lxc',
             STATUS  => STATUS_RUNNING,
             MAC     => 'fa:ee:26:ef:6b:1c',
-            MEMORY  => 2147483648,
+            MEMORY  => 2048,
             VCPU    => 2
         }
     },


### PR DESCRIPTION
Issue:
The glpi-agent was incorrectly handling memory values for LXC containers on hosts using Proxmox.
Proxmox returns a raw byte value (e.g., "10737418240") without a unit suffix, and the current logic
in getCanonicalSize() immediately returns such plain numeric values. This leads to storing the
value in bytes instead of the expected megabytes (MB), potentially causing an overflow in an
unsigned int database column.

Solution:
- For values ending with a unit (K, M, G, T, or P), the code appends "b" (e.g., "16384M" becomes "16384Mb")
  so that getCanonicalSize() processes them correctly.
- For plain numeric values (e.g., "10737418240"), the code now detects them using a regex and converts
  the value from bytes to MB by dividing by (1024 * 1024).

Changes:
- Added an `elsif` branch to check if the memory value is a plain number using `/^\d+$/`.
- For these numeric values, the code converts them to MB via:
  `int($val / (1024 * 1024))`
- Retained the existing logic for values with a unit suffix to preserve backward compatibility.