### PR TITLE
Added modules for antivirus programs Dr.Web and KESL

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
@@ -62,11 +62,23 @@ sub _getDrWebInfo {
     );
 
     foreach my $line (@baseinfo) {
-        if ($line =~ /Virus database timestamp:\s+(.+)/) {
-            $av->{BASE_VERSION} = $1;
+        if ($line =~ /^Virus database timestamp:\s+(\d+)-(\w+)-(\d+)/) {
+            my $month_num = month($2) || 0;
+            $av->{BASE_VERSION} = sprintf("%d-%02d-%02d", $1, $month_num, $3);
             last;
         }
     }
+
+    my $expiration = getFirstMatch(
+        command => 'drweb-ctl license',
+        pattern => qr/expires (\d+-\w+-\d+)/,
+        %params
+    );
+    if ($expiration && $expiration =~ /^(\d+)-(\w+)-(\d+)$/) {
+        my $m = month($2);
+        $av->{EXPIRATION} = sprintf("%d-%02d-%02d", $1, $m, $3) if $m;
+    }
+
 
     return $av;
 }

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
@@ -42,7 +42,7 @@ sub _getDrWebInfo {
     };
 
     my $version_output = getFirstLine(
-        command => 'LANG=C drweb-ctl --version',
+        command => 'drweb-ctl --version',
         %params
     );
 
@@ -51,13 +51,13 @@ sub _getDrWebInfo {
     }
 
     my $service_status = getFirstLine(
-        command => 'LANG=C systemctl is-active drweb-configd.service',
+        command => 'systemctl is-active drweb-configd.service',
         %params
     );
     $av->{ENABLED} = $service_status && $service_status eq 'active' ? 1 : 0;
 
     my @baseinfo = getAllLines(
-        command => 'LANG=C drweb-ctl baseinfo',
+        command => 'drweb-ctl baseinfo',
         %params
     );
 

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
@@ -5,7 +5,6 @@ use warnings;
 use parent 'GLPI::Agent::Task::Inventory::Module';
 
 use GLPI::Agent::Tools;
-use Time::Piece;
 
 sub isEnabled {
     return canRun('drweb-ctl');
@@ -26,9 +25,7 @@ sub doInventory {
 
         $logger->debug2("Added $antivirus->{NAME}" .
             ($antivirus->{VERSION} ? " v$antivirus->{VERSION}" : "") .
-            ($antivirus->{ENABLED} ? " [ENABLED]" : " [DISABLED]") .
-            ($antivirus->{EXPIRATION} ? " Expires: $antivirus->{EXPIRATION}" :
-             $antivirus->{SERVER_LICENSE} ? " [Server-managed license]" : ""))
+            ($antivirus->{ENABLED} ? " [ENABLED]" : " [DISABLED]"))
             if $logger;
     }
 }
@@ -44,71 +41,29 @@ sub _getDrWebInfo {
         UPTODATE => 0,               
     };
 
-    # 1. Get product version information
     my $version_output = getFirstLine(
-        command => 'drweb-ctl --version 2>/dev/null',
+        command => 'LANG=C drweb-ctl --version',
         %params
     );
 
-    # Extract version number if available
     if ($version_output && $version_output =~ /drweb-ctl\s+([\d.]+)/) {
         $av->{VERSION} = $1;
     }
 
-    # 2. Check if Dr.Web service is running
     my $service_status = getFirstLine(
-        command => 'systemctl is-active drweb-configd.service 2>/dev/null',
+        command => 'LANG=C systemctl is-active drweb-configd.service',
         %params
     );
-    # Set ENABLED flag based on service status
     $av->{ENABLED} = $service_status && $service_status eq 'active' ? 1 : 0;
 
-    # 3. Get antivirus database information
     my @baseinfo = getAllLines(
-        command => 'drweb-ctl baseinfo 2>/dev/null',
+        command => 'LANG=C drweb-ctl baseinfo',
         %params
     );
 
-    my ($db_timestamp);
-    # Parse database timestamp from output
     foreach my $line (@baseinfo) {
         if ($line =~ /Virus database timestamp:\s+(.+)/) {
-            $db_timestamp = $1;
-            $av->{BASE_VERSION} = $1;  # Store raw timestamp string
-            last;
-        }
-    }
-
-    # Check if database is up-to-date (within 2 days)
-    if ($db_timestamp) {
-        eval {
-            my $db_time = Time::Piece->strptime($db_timestamp, "%Y-%b-%d %H:%M:%S");
-            my $diff = time() - $db_time->epoch;
-            $av->{UPTODATE} = ($diff <= 172800) ? 1 : 0;  # 172800 seconds = 2 days
-        };
-        $av->{UPTODATE} = 0 if $@;
-    }
-
-    # 4. Get license information
-    my @license_info = getAllLines(
-        command => 'drweb-ctl license 2>/dev/null',
-        %params
-    );
-
-    # Parse license information
-    foreach my $line (@license_info) {
-        if ($line =~ /expires\s+(\d{4}-\w{3}-\d{1,2})(?:\s|$)/i) {
-            eval {
-                my $expire_time = Time::Piece->strptime($1, "%Y-%b-%d");
-                $av->{EXPIRATION} = $expire_time->strftime("%Y-%m-%d"); 
-            };
-            if ($@) {
-                $logger->debug("Failed to parse license expiration: $@");
-            }
-            last;
-        }
-        elsif ($line =~ /license is granted by the protection server/i) {
-            $av->{SERVER_LICENSE} = 1;
+            $av->{BASE_VERSION} = $1;
             last;
         }
     }

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
@@ -62,10 +62,8 @@ sub _getDrWebInfo {
     );
 
     foreach my $line (@baseinfo) {
-        if ($line =~ /^Virus database timestamp:\s+(\d+)-(\w+)-(\d+)/) {
-            my $month_num = month($2) || 0;
-            $av->{BASE_VERSION} = sprintf("%d-%02d-%02d", $1, $month_num, $3);
-            last;
+        if ($line =~ /^Virus database timestamp:\s+(\S+)/) {
+            $av->{BASE_VERSION} = $1;
         }
     }
 

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
@@ -1,0 +1,119 @@
+package GLPI::Agent::Task::Inventory::Linux::AntiVirus::DrWeb;
+
+use strict;
+use warnings;
+use parent 'GLPI::Agent::Task::Inventory::Module';
+
+use GLPI::Agent::Tools;
+use Time::Piece;
+
+sub isEnabled {
+    return canRun('drweb-ctl');
+}
+
+sub doInventory {
+    my (%params) = @_;
+
+    my $inventory = $params{inventory};
+    my $logger    = $params{logger};
+
+    my $antivirus = _getDrWebInfo(logger => $logger);
+    if ($antivirus) {
+        $inventory->addEntry(
+            section => 'ANTIVIRUS',
+            entry   => $antivirus
+        );
+
+        $logger->debug2("Added $antivirus->{NAME}" .
+            ($antivirus->{VERSION} ? " v$antivirus->{VERSION}" : "") .
+            ($antivirus->{ENABLED} ? " [ENABLED]" : " [DISABLED]") .
+            ($antivirus->{EXPIRATION} ? " Expires: $antivirus->{EXPIRATION}" :
+             $antivirus->{SERVER_LICENSE} ? " [Server-managed license]" : ""))
+            if $logger;
+    }
+}
+
+sub _getDrWebInfo {
+    my (%params) = @_;
+    my $logger = $params{logger};
+
+    my $av = {
+        NAME     => 'Dr.Web',
+        COMPANY  => 'Doctor Web',  
+        ENABLED  => 0,               
+        UPTODATE => 0,               
+    };
+
+    # 1. Get product version information
+    my $version_output = getFirstLine(
+        command => 'drweb-ctl --version 2>/dev/null',
+        %params
+    );
+
+    # Extract version number if available
+    if ($version_output && $version_output =~ /drweb-ctl\s+([\d.]+)/) {
+        $av->{VERSION} = $1;
+    }
+
+    # 2. Check if Dr.Web service is running
+    my $service_status = getFirstLine(
+        command => 'systemctl is-active drweb-configd.service 2>/dev/null',
+        %params
+    );
+    # Set ENABLED flag based on service status
+    $av->{ENABLED} = $service_status && $service_status eq 'active' ? 1 : 0;
+
+    # 3. Get antivirus database information
+    my @baseinfo = getAllLines(
+        command => 'drweb-ctl baseinfo 2>/dev/null',
+        %params
+    );
+
+    my ($db_timestamp);
+    # Parse database timestamp from output
+    foreach my $line (@baseinfo) {
+        if ($line =~ /Virus database timestamp:\s+(.+)/) {
+            $db_timestamp = $1;
+            $av->{BASE_VERSION} = $1;  # Store raw timestamp string
+            last;
+        }
+    }
+
+    # Check if database is up-to-date (within 2 days)
+    if ($db_timestamp) {
+        eval {
+            my $db_time = Time::Piece->strptime($db_timestamp, "%Y-%b-%d %H:%M:%S");
+            my $diff = time() - $db_time->epoch;
+            $av->{UPTODATE} = ($diff <= 172800) ? 1 : 0;  # 172800 seconds = 2 days
+        };
+        $av->{UPTODATE} = 0 if $@;
+    }
+
+    # 4. Get license information
+    my @license_info = getAllLines(
+        command => 'drweb-ctl license 2>/dev/null',
+        %params
+    );
+
+    # Parse license information
+    foreach my $line (@license_info) {
+        if ($line =~ /expires\s+(\d{4}-\w{3}-\d{1,2})(?:\s|$)/i) {
+            eval {
+                my $expire_time = Time::Piece->strptime($1, "%Y-%b-%d");
+                $av->{EXPIRATION} = $expire_time->strftime("%Y-%m-%d"); 
+            };
+            if ($@) {
+                $logger->debug("Failed to parse license expiration: $@");
+            }
+            last;
+        }
+        elsif ($line =~ /license is granted by the protection server/i) {
+            $av->{SERVER_LICENSE} = 1;
+            last;
+        }
+    }
+
+    return $av;
+}
+
+1;

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/DrWeb.pm
@@ -32,13 +32,12 @@ sub doInventory {
 
 sub _getDrWebInfo {
     my (%params) = @_;
-    my $logger = $params{logger};
 
     my $av = {
         NAME     => 'Dr.Web',
-        COMPANY  => 'Doctor Web',  
-        ENABLED  => 0,               
-        UPTODATE => 0,               
+        COMPANY  => 'Doctor Web',
+        ENABLED  => 0,
+        UPTODATE => 0,
     };
 
     my $version_output = getFirstLine(

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
@@ -1,0 +1,101 @@
+package GLPI::Agent::Task::Inventory::Linux::AntiVirus::KESL;
+
+use strict;
+use warnings;
+use parent 'GLPI::Agent::Task::Inventory::Module';
+
+use GLPI::Agent::Tools;
+use Time::Piece;
+
+sub isEnabled {
+    return canRun('kesl-control');
+}
+
+sub doInventory {
+    my (%params) = @_;
+
+    my $inventory = $params{inventory};
+    my $logger    = $params{logger};
+
+    my $antivirus = _getKESLInfo(logger => $logger);
+    if ($antivirus) {
+        $inventory->addEntry(
+            section => 'ANTIVIRUS',
+            entry   => $antivirus
+        );
+
+        $logger->debug2("Added $antivirus->{NAME}" .
+            ($antivirus->{VERSION} ? " v$antivirus->{VERSION}" : "") .
+            ($antivirus->{ENABLED} ? " [ENABLED]" : " [DISABLED]") .
+            ($antivirus->{EXPIRATION} ? " Expires: $antivirus->{EXPIRATION}" : ""))
+            if $logger;
+    }
+}
+
+sub _getKESLInfo {
+    my (%params) = @_;
+    my $logger = $params{logger};
+
+    my $av = {
+        NAME     => 'Kaspersky Endpoint Security for Linux', 
+        COMPANY  => 'Kaspersky Lab',
+        ENABLED  => 0,               
+        UPTODATE => 0,
+    };
+
+    # 1. Check if KESL service is running via systemd
+    my $service_status = getFirstLine(
+        command => 'systemctl is-active kesl.service 2>/dev/null',
+        %params
+    );
+    # Set ENABLED flag based on service status (active = 1, inactive = 0)
+    $av->{ENABLED} = $service_status && $service_status eq 'active' ? 1 : 0;
+
+    # 2. Get product version information
+    my $version_output = getFirstLine(
+        command => 'kesl-control --app-info 2>/dev/null | grep -E "Version|Версия"',
+        %params
+    );
+    # Extract version number from either English or Russian output
+    if ($version_output && $version_output =~ /(?:Version|Версия):\s+([\d.]+)/) {
+        $av->{VERSION} = $1;
+    }
+
+    # 3. Get license expiration information
+    my $license_output = getFirstLine(
+        command => 'kesl-control --app-info 2>/dev/null | grep -E "License expiration date|Дата окончания срока действия лицензии"',
+        %params
+    );
+    # Parse expiration date from either English or Russian output
+    if ($license_output && $license_output =~ /(?:License expiration date|Дата окончания срока действия лицензии):\s+([\d-]+)/) {
+        eval {
+            my $expire_time = Time::Piece->strptime($1, "%Y-%m-%d");
+            $av->{EXPIRATION} = $expire_time->strftime("%Y-%m-%d");
+        };
+        if ($@) {
+            $logger->debug("Failed to parse license expiration: $@");
+        }
+    }
+
+    # 4. Get antivirus database update information
+    my $db_date_output = getFirstLine(
+        command => 'kesl-control --app-info 2>/dev/null | grep -E "Last release date of databases|Дата последнего выпуска баз приложения"',
+        %params
+    );
+    # Parse database timestamp from either English or Russian output
+    if ($db_date_output && $db_date_output =~ /(?:Last release date of databases|Дата последнего выпуска баз приложения):\s+([\d-]+\s[\d:]+)/) {
+        eval {
+            my $db_time = Time::Piece->strptime($1, "%Y-%m-%d %H:%M:%S");
+            my $diff = time() - $db_time->epoch;
+            # Mark as up-to-date if databases are less than 2 days old (172800 seconds)
+            $av->{UPTODATE} = ($diff <= 172800) ? 1 : 0;
+        };
+        if ($@) {
+            $logger->debug("Failed to parse database timestamp: $@");
+        }
+    }
+
+    return $av;
+}
+
+1;

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
@@ -33,7 +33,6 @@ sub doInventory {
 
 sub _getKESLInfo {
     my (%params) = @_;
-    my $logger = $params{logger};
 
     my $av = {
         NAME     => 'Kaspersky Endpoint Security for Linux',

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
@@ -43,29 +43,29 @@ sub _getKESLInfo {
     };
 
     my $service_status = getFirstLine(
-        command => 'LANG=en_US.UTF-8 systemctl is-active kesl.service',
+        command => 'systemctl is-active kesl.service',
         %params
     );
     $av->{ENABLED} = $service_status && $service_status eq 'active' ? 1 : 0;
 
     my @app_info = getAllLines(
-        command => 'LANG=en_US.UTF-8 kesl-control --app-info',
+        command => 'kesl-control --app-info',
         %params
     );
 
     foreach my $line (@app_info) {
 
-        if (!$av->{VERSION} && $line =~ /Version:\s+([\d.]+)/) {
+        if (!$av->{VERSION} && $line =~ /^Version:\s+([\d.]+)/) {
             $av->{VERSION} = $1;
             next;
         }
 
-        if (!$av->{EXPIRATION} && $line =~ /license expiration date:\s+([\d-]+\s[\d:]+)/i) {
+        if (!$av->{EXPIRATION} && $line =~ /license expiration date:\s+([\d-]+)/i) {
             $av->{EXPIRATION} = $1;
             next;
         }
 
-        if (!$av->{BASE_VERSION} && $line =~ /Last release date of databases:\s+([\d-]+\s[\d:]+)/) {
+        if (!$av->{BASE_VERSION} && $line =~ /^Last release date of databases:\s+([\d-]+)/) {
             $av->{BASE_VERSION} = $1;
             next;
         }

--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/KESL.pm
@@ -5,7 +5,6 @@ use warnings;
 use parent 'GLPI::Agent::Task::Inventory::Module';
 
 use GLPI::Agent::Tools;
-use Time::Piece;
 
 sub isEnabled {
     return canRun('kesl-control');
@@ -37,61 +36,38 @@ sub _getKESLInfo {
     my $logger = $params{logger};
 
     my $av = {
-        NAME     => 'Kaspersky Endpoint Security for Linux', 
+        NAME     => 'Kaspersky Endpoint Security for Linux',
         COMPANY  => 'Kaspersky Lab',
-        ENABLED  => 0,               
+        ENABLED  => 0,
         UPTODATE => 0,
     };
 
-    # 1. Check if KESL service is running via systemd
     my $service_status = getFirstLine(
-        command => 'systemctl is-active kesl.service 2>/dev/null',
+        command => 'LANG=en_US.UTF-8 systemctl is-active kesl.service',
         %params
     );
-    # Set ENABLED flag based on service status (active = 1, inactive = 0)
     $av->{ENABLED} = $service_status && $service_status eq 'active' ? 1 : 0;
 
-    # 2. Get product version information
-    my $version_output = getFirstLine(
-        command => 'kesl-control --app-info 2>/dev/null | grep -E "Version|Версия"',
+    my @app_info = getAllLines(
+        command => 'LANG=en_US.UTF-8 kesl-control --app-info',
         %params
     );
-    # Extract version number from either English or Russian output
-    if ($version_output && $version_output =~ /(?:Version|Версия):\s+([\d.]+)/) {
-        $av->{VERSION} = $1;
-    }
 
-    # 3. Get license expiration information
-    my $license_output = getFirstLine(
-        command => 'kesl-control --app-info 2>/dev/null | grep -E "License expiration date|Дата окончания срока действия лицензии"',
-        %params
-    );
-    # Parse expiration date from either English or Russian output
-    if ($license_output && $license_output =~ /(?:License expiration date|Дата окончания срока действия лицензии):\s+([\d-]+)/) {
-        eval {
-            my $expire_time = Time::Piece->strptime($1, "%Y-%m-%d");
-            $av->{EXPIRATION} = $expire_time->strftime("%Y-%m-%d");
-        };
-        if ($@) {
-            $logger->debug("Failed to parse license expiration: $@");
+    foreach my $line (@app_info) {
+
+        if (!$av->{VERSION} && $line =~ /Version:\s+([\d.]+)/) {
+            $av->{VERSION} = $1;
+            next;
         }
-    }
 
-    # 4. Get antivirus database update information
-    my $db_date_output = getFirstLine(
-        command => 'kesl-control --app-info 2>/dev/null | grep -E "Last release date of databases|Дата последнего выпуска баз приложения"',
-        %params
-    );
-    # Parse database timestamp from either English or Russian output
-    if ($db_date_output && $db_date_output =~ /(?:Last release date of databases|Дата последнего выпуска баз приложения):\s+([\d-]+\s[\d:]+)/) {
-        eval {
-            my $db_time = Time::Piece->strptime($1, "%Y-%m-%d %H:%M:%S");
-            my $diff = time() - $db_time->epoch;
-            # Mark as up-to-date if databases are less than 2 days old (172800 seconds)
-            $av->{UPTODATE} = ($diff <= 172800) ? 1 : 0;
-        };
-        if ($@) {
-            $logger->debug("Failed to parse database timestamp: $@");
+        if (!$av->{EXPIRATION} && $line =~ /license expiration date:\s+([\d-]+\s[\d:]+)/i) {
+            $av->{EXPIRATION} = $1;
+            next;
+        }
+
+        if (!$av->{BASE_VERSION} && $line =~ /Last release date of databases:\s+([\d-]+\s[\d:]+)/) {
+            $av->{BASE_VERSION} = $1;
+            next;
         }
     }
 


### PR DESCRIPTION
Added modules for antivirus programs Dr.Web and Kaspersky Endpoint Security.

These modules use `Time::Piece` for:

#### 1. Data analysis

Converts data strings from the antivirus output (for example, 2025-06-09, February 15, 2023) into temporary objects.

Supports:

- KESL: Accurate timestamps (2025-05-09, 19:20:00).
- Dr.Web: Localized month names (February/June).

#### 2. Time check

Compares the dates with the current time to check:

- The license is valid (expired or not).
- The freshness of the database (whether it has been updated in the last 2 days).

Some Linux distributions do not include the `Time::Piece` module by default, requiring manual installation.