### PR TITLE
Fix error when DB name is only a number during MSSQL database inventory

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Generic/Databases/MSSQL.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Generic/Databases/MSSQL.pm
@@ -126,7 +126,7 @@ sub _getDatabaseService {
                 or next;
 
             my ($size) = _runSql(
-                sql => "USE $db_name ; EXEC sp_spaceused",
+                sql => "USE [$db_name] ; EXEC sp_spaceused",
                 %params
             ) =~ /^$db_name;([0-9.]+\s*\S+);/;
             if ($size) {
@@ -138,7 +138,7 @@ sub _getDatabaseService {
 
             # Find update date
             my ($updated) = _runSql(
-                sql => "USE $db_name ; SELECT TOP(1) modify_date FROM sys.objects ORDER BY modify_date DESC",
+                sql => "USE [$db_name] ; SELECT TOP(1) modify_date FROM sys.objects ORDER BY modify_date DESC",
                 %params
             ) =~ /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/;
 


### PR DESCRIPTION
When the database name is only a number, which is often the case with Exact Globe (Next)+, The script will produce errors when retrieving information about the database.
This fixes those errors