### PR TITLE
Add ESET Endpoint Antivirus for Linux support

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/EEA.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Linux/AntiVirus/EEA.pm
@@ -1,0 +1,88 @@
+package GLPI::Agent::Task::Inventory::Linux::AntiVirus::EEA;
+
+use strict;
+use warnings;
+
+use parent 'GLPI::Agent::Task::Inventory::Module';
+
+use POSIX qw(mktime);
+
+use GLPI::Agent::Tools;
+
+use constant upd => '/opt/eset/eea/bin/upd';
+use constant lic => '/opt/eset/eea/sbin/lic';
+
+sub isEnabled {
+    return canRun(upd) && canRun(lic);
+}
+
+sub doInventory {
+    my (%params) = @_;
+
+    my $inventory = $params{inventory};
+    my $logger    = $params{logger};
+
+    my $antivirus = _getEEAInfo(logger => $logger);
+    if ($antivirus) {
+        $inventory->addEntry(
+            section => 'ANTIVIRUS',
+            entry   => $antivirus
+        );
+
+        $logger->debug2("Added $antivirus->{NAME}" .
+            ($antivirus->{VERSION} ? " v$antivirus->{VERSION}" : "") .
+            ($antivirus->{ENABLED} ? " [ENABLED]" : " [DISABLED]"))
+            if $logger;
+    }
+}
+
+sub _getEEAInfo {
+    my (%params) = @_;
+
+    my $av = {
+        NAME     => 'ESET Endpoint Antivirus',
+        COMPANY  => 'ESET',
+        ENABLED  => 0,
+        UPTODATE => 0,
+    };
+
+    my $version = getFirstMatch(
+        pattern => qr/\(eea\)\s*([0-9.]+)/,
+        command => upd . " -version",
+        %params
+    );
+    $av->{VERSION} = $version if $version;
+
+    my $service_status = getFirstLine(
+        command => 'systemctl is-active eea.service',
+        %params
+    );
+    $av->{ENABLED} = $service_status && $service_status eq 'active' ? 1 : 0;
+
+    my $expiration = getFirstMatch(
+        command => lic . ' --status',
+        pattern => qr/License Validity:\s*(\d{4}-\d{2}-\d{2})/,
+        %params
+    );
+    $av->{EXPIRATION} = $expiration if $expiration;
+
+    my $base_version = getFirstMatch(
+        command => upd . ' --list-modules',
+        pattern => qr/EM002\s*(\d+\s*\(\d+\))\s*Detection engine$/,
+        %params
+    );
+    $av->{BASE_VERSION} = $base_version if $base_version;
+
+    # Since ESET does not allow us to check if we are up to date without forcing a module update
+    # "upd -u" has no dry-run or check options.
+    # Let's consider that we are up to date if the antivirus database is less than 2 days old.
+    if ($base_version =~ /\((\d{4})(\d{2})(\d{2})\)$/) {
+        my $two_days_ago = time - 2 * 24 * 60 * 60;
+
+        $av->{UPTODATE} = mktime(0, 0, 0, $3, $2-1, $1-1900) > $two_days_ago ? 1 : 0;
+    }
+
+    return $av;
+}
+
+1;


### PR DESCRIPTION
This PR adds support for ESET Endpoint Antivirus (EEA) for Linux. 

⚠️ Note: this is not ESET Server Security, but the "Desktop" version of the ESET antivirus, This is why I named the module EEA.

The reported information is identical to what the Windows agent provides.

Unfortunately, ESET does not offer any method to check whether the component is up to date (no dry-run or check mode) without actually performing a module upgrade. Therefore, the uptodate field is not really accurate.

```
# glpi-inventory --partial antivirus
[info] New inventory from XXXXXX-2025-09-04-17-00-31 for local0
{
   "action": "inventory",
   "content": {
      "antivirus": [
         {
            "base_version": "31807 (20250904)",
            "company": "ESET",
            "enabled": true,
            "expiration": "2026-06-21",
            "name": "ESET Endpoint Antivirus",
            "uptodate": false,
            "version": "12.0.13.0"
         }
      ],
```