### PR TITLE
Add support for ssl_key_file (as required for client certificate auth)

### DIFF
--- a/bin/glpi-agent
+++ b/bin/glpi-agent
@@ -84,6 +84,8 @@ GetOptions(
     'vardir=s',
     'version',
     'wait|w=s',
+    "ssl-cert-file=s",
+    "ssl-key-file=s",
     # Platform specific option
     'no-win32-ole-workaround'
 ) or pod2usage(-verbose => 0);
@@ -312,6 +314,10 @@ glpi-agent [options] [--server server|--local path]
     -C --no-compression            do not compress communication with server
                                      (false)
     --timeout=TIME                 connection timeout, in seconds (180)
+
+    --ssl-cert-file=FILE           ssl client certificate file
+    --ssl-key-file=FILE            ssl client private key file
+                                   (asumed included in cert file if missing)
 
   Web interface options:
     --no-httpd                     disable embedded web server (false)
@@ -696,6 +702,15 @@ Do not check server SSL certificate.
 =item B<--timeout>=I<TIME>
 
 Timeout for server connections.
+
+=item B<--ssl-cert-file>=I<FILE>
+
+SSL client certificate filename.
+
+=item B<--ssl-key-file>=I<FILE>
+
+SSL client private key filename.
+If missing, assumed is included in cert file
 
 =back
 

--- a/bin/glpi-injector
+++ b/bin/glpi-injector
@@ -35,6 +35,7 @@ GetOptions(
     'no-ssl-check',
     'ca-cert-file=s',
     'ssl-cert-file=s',
+    'ssl-key-file=s',
     'ssl-fingerprint=s',
     'proxy|P=s',
     'url|u=s',
@@ -393,7 +394,8 @@ glpi-injector [-h|--help] [-R|--recursive] [-r|--remove] [-v|--verbose] [--debug
                    use Client version found in XML or JSON as User-Agent for POST
     --no-ssl-check do not check server SSL certificate
     --ca-cert-file=FILE CA certificates file
-    --ssl-cert-file client certificate file
+    --ssl-cert-file=FILE client certificate file
+    --ssl-key-file=FILE client private key file (asumed included in cert file if missing)
     --ssl-fingerprint=FINGERPRINT Trust server certificate on its SSL fingerprint
     -C --no-compression don't compress sent XML inventories
     -P --proxy=PROXY proxy address

--- a/bin/glpi-remote
+++ b/bin/glpi-remote
@@ -61,6 +61,7 @@ GetOptions(
     'ca-cert-file=s',
     'ca-cert-dir=s',
     'ssl-cert-file=s',
+    'ssl-key-file=s',
     'ssl-fingerprint=s',
     'stricthostkeychecking=s',
     'no-ssl-check|S',
@@ -591,7 +592,8 @@ glpi-remote [options] [--server server|--local path] [command] [command options]
     --ca-cert-file <FILE> CA certificates file (winrm or for agent sub-command)
     --ssl-fingerprint <FINGERPRINT>
                         Trust server certificate if its SSL fingerprint matches the given one
-    --ssl-cert-file     Client certificate file (winrm)
+    --ssl-cert-file <FILE> Client certificate file (winrm)
+    --ssl-key-file <FILE>  Client private key file (asumed included in cert file if missing)
     -u --user           authentication user
     -P --password       authentication password
     -X --show-passwords (list command) show password as they are masked by default
@@ -747,6 +749,11 @@ CA certificates file.
 =item B<--ssl-cert-file>=I<FILE>
 
 SSL certificate file for authentication
+
+=item B<--ssl-key-file>=I<FILE>
+
+SSL client private key filename.
+If missing, assumed is included in cert file
 
 =item B<--no-ssl-check>
 

--- a/etc/agent.cfg
+++ b/etc/agent.cfg
@@ -109,7 +109,7 @@ timeout = 180
 
 # ssl client certificate filename
 ssl-cert-file =
-# ssl client key filename
+# ssl client private key filename
 # (If key file is missing assume it is included in cert file)
 ssl-key-file = 
 

--- a/etc/agent.cfg
+++ b/etc/agent.cfg
@@ -107,6 +107,12 @@ no-ssl-check = 0
 # connection timeout, in seconds
 timeout = 180
 
+# ssl client certificate filename
+ssl-cert-file =
+# ssl client key filename
+# (If key file is missing assume it is included in cert file)
+ssl-key-file = 
+
 #
 # Web interface options
 #

--- a/lib/GLPI/Agent/Config.pm
+++ b/lib/GLPI/Agent/Config.pm
@@ -55,6 +55,7 @@ my $default = {
     'scan-profiles'           => undef,
     'server'                  => undef,
     'ssl-cert-file'           => undef,
+    'ssl-key-file'            => undef,
     'ssl-fingerprint'         => undef,
     'ssl-keystore'            => undef,
     'tag'                     => undef,

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -44,7 +44,7 @@ sub new {
         if $ssl_cert_file && ! -f $ssl_cert_file;
 
     my $ssl_key_file = $params{ssl_key_file} || $config->{'ssl-key-file'};
-    die "non-existing client certificate file $ssl_key_file"
+    die "non-existing client private key file $ssl_key_file"
         if $ssl_key_file && ! -f $ssl_key_file;
 
     # We should still keep SSL certs cache if running in long running netdiscovery

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -43,6 +43,10 @@ sub new {
     die "non-existing client certificate file $ssl_cert_file"
         if $ssl_cert_file && ! -f $ssl_cert_file;
 
+    my $ssl_key_file = $params{ssl_key_file} || $config->{'ssl-key-file'};
+    die "non-existing client certificate file $ssl_key_file"
+        if $ssl_key_file && ! -f $ssl_key_file;
+
     # We should still keep SSL certs cache if running in long running netdiscovery
     # or netinventory task with expiration set in a dedicated thread
     $_SSL_ca->{_expiration} = getExpirationTime()
@@ -60,6 +64,7 @@ sub new {
         ca_cert_dir     => $ca_cert_dir,
         ca_cert_file    => $ca_cert_file,
         ssl_cert_file   => $ssl_cert_file,
+        ssl_key_file    => $ssl_key_file,
         ssl_fingerprint => $params{ssl_fingerprint} || $config->{'ssl-fingerprint'},
         ssl_keystore    => $params{ssl_keystore} || $config->{'ssl-keystore'},
         _vardir         => $config->{'vardir'},
@@ -514,6 +519,9 @@ sub _setSSLOptions {
                 if $self->{ca_cert_dir};
             $self->{ua}->ssl_opts(SSL_cert_file => $self->{ssl_cert_file})
                 if $self->{ssl_cert_file};
+            $self->{ua}->ssl_opts(SSL_key_file => $self->{ssl_key_file})
+                if $self->{ssl_key_file};
+
             $self->{ua}->ssl_opts(SSL_fingerprint => $self->{ssl_fingerprint})
                 if $self->{ssl_fingerprint} && $IO::Socket::SSL::VERSION >= 1.967;
             # Use SSL_ca option to support system keychain or keystore to add

--- a/lib/GLPI/Agent/HTTP/Client.pm
+++ b/lib/GLPI/Agent/HTTP/Client.pm
@@ -542,6 +542,7 @@ sub _setSSLOptions {
                 ca_cert_file => $self->{ca_cert_file},
                 ca_cert_dir  => $self->{ca_cert_dir},
                 ssl_cert_file => $self->{ssl_cert_file},
+                ssl_key_file => $self->{ssl_key_file},
                 ssl_fingerprint => $self->{ssl_fingerprint},
                 ssl_ca => $SSL_ca,
             );

--- a/lib/GLPI/Agent/HTTP/Protocol/https.pm
+++ b/lib/GLPI/Agent/HTTP/Protocol/https.pm
@@ -16,6 +16,8 @@ sub import {
         if $params{ca_cert_dir};
     IO::Socket::SSL::set_ctx_defaults(ssl_cert_file => $params{ssl_cert_file})
         if $params{ssl_cert_file};
+    IO::Socket::SSL::set_ctx_defaults(ssl_key_file => $params{ssl_key_file})
+        if $params{ssl_key_file};
     IO::Socket::SSL::set_ctx_defaults(ssl_ca => $params{ssl_ca})
         if $params{ssl_ca};
     IO::Socket::SSL::set_ctx_defaults(ssl_fingerprint => $params{ssl_fingerprint})


### PR DESCRIPTION
This patch allows the client to pass the SSL key file (along with the already provided SSL certificate file) to the LWP client, so that we can use a custom SSL certificate, as required by the server when client certificate authentication is required.