### PR TITLE
Fix systemd warning about unset variable

### DIFF
--- a/contrib/unix/glpi-agent.service
+++ b/contrib/unix/glpi-agent.service
@@ -19,6 +19,7 @@ Documentation=man:glpi-agent
 After=syslog.target network.target
 
 [Service]
+Environment="OPTIONS="
 ExecStart=/usr/bin/glpi-agent --daemon --no-fork $OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 CapabilityBoundingSet=~CAP_SYS_PTRACE


### PR DESCRIPTION
The file `contrib/unix/glpi-agent.service` contains the line

    ExecStart=/usr/bin/glpi-agent --daemon --no-fork $OPTIONS

As systemd v254 has [become more strict in its parsing of environment variables][systemd], the line above now generates the following warning:

    glpi-agent.service: Referenced but unset environment variable evaluates to an empty string: OPTIONS

This pull request suppresses the warning by explicitly defining `OPTIONS` to the empty string. It is still possible to override the variable with `systemctl edit`, as explained in a comment within the file.

[systemd]: https://github.com/systemd/systemd/commit/f331434d13488425ccd8