### PR TITLE
fix: use launchctl bootstrap/bootout on macOS 13 Ventura and later

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,9 @@ toolbox:
 * Fix undefined error on Results page while tag_filter is not set
 
 packaging:
+* fix: Update macOS postinstall, preinstall and uninstaller to use launchctl
+  bootstrap/bootout on macOS 13 Ventura and later, where launchctl load/unload
+  is deprecated and returns an error
 * Update Windows packaging to use:
   - Perl 5.42.2
   - gcc 16.1.0posix-14.0.0-msvcrt-r2

--- a/contrib/macosx/scripts/postinstall
+++ b/contrib/macosx/scripts/postinstall
@@ -42,6 +42,7 @@ fi
 echo "Only Tiger or newer OS supported, using LaunchDaemons plists"
 TMPPLIST="$(touch com.teclib.glpi-agent.plist && echo com.teclib.glpi-agent.plist || mktemp -t com.teclib.glpi-agent)"
 TPATH="/Library/LaunchDaemons"
+MACOS_MAJOR=$(sw_vers -productVersion | cut -d. -f1)
 cat >"$TMPPLIST" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -72,10 +73,13 @@ if [ -s "$TMPPLIST" ]; then
     rm -f "$TMPPLIST"
 
     echo 'Loading Service'
-    sudo launchctl load $TPATH/com.teclib.glpi-agent.plist
-
-    echo 'Starting Service'
-    sudo launchctl start com.teclib.glpi-agent
+    if [ "${MACOS_MAJOR:-0}" -ge 13 ]; then
+        sudo launchctl bootstrap system $TPATH/com.teclib.glpi-agent.plist
+    else
+        sudo launchctl load $TPATH/com.teclib.glpi-agent.plist
+        echo 'Starting Service'
+        sudo launchctl start com.teclib.glpi-agent
+    fi
 else
     echo "Failed to create service"
 fi

--- a/contrib/macosx/scripts/preinstall
+++ b/contrib/macosx/scripts/preinstall
@@ -6,17 +6,26 @@ DEST="$2"
 INSTALL_PATH="${DEST%/}/Applications/GLPI-Agent"
 
 # Stop service and unload plist file if present
+MACOS_MAJOR=$(sw_vers -productVersion | cut -d. -f1)
 # Case for glpi-agent > 1.6.1
 if [ -e /Library/LaunchDaemons/com.teclib.glpi-agent.plist ]; then
     echo "Stopping service"
-    sudo launchctl stop com.teclib.glpi-agent
-    sudo launchctl unload /Library/LaunchDaemons/com.teclib.glpi-agent.plist
+    if [ "${MACOS_MAJOR:-0}" -ge 13 ]; then
+        sudo launchctl bootout system /Library/LaunchDaemons/com.teclib.glpi-agent.plist
+    else
+        sudo launchctl stop com.teclib.glpi-agent
+        sudo launchctl unload /Library/LaunchDaemons/com.teclib.glpi-agent.plist
+    fi
 fi
 # Case for glpi-agent <= 1.6.1
 if [ -e /Library/LaunchDaemons/org.glpi-project.glpi-agent.plist ]; then
     echo "Stopping service"
-    sudo launchctl stop org.glpi-project.glpi-agent
-    sudo launchctl unload /Library/LaunchDaemons/org.glpi-project.glpi-agent.plist
+    if [ "${MACOS_MAJOR:-0}" -ge 13 ]; then
+        sudo launchctl bootout system /Library/LaunchDaemons/org.glpi-project.glpi-agent.plist
+    else
+        sudo launchctl stop org.glpi-project.glpi-agent
+        sudo launchctl unload /Library/LaunchDaemons/org.glpi-project.glpi-agent.plist
+    fi
     sudo rm -f /Library/LaunchDaemons/org.glpi-project.glpi-agent.plist
 fi
 

--- a/contrib/macosx/scripts/uninstaller.sh
+++ b/contrib/macosx/scripts/uninstaller.sh
@@ -5,8 +5,13 @@ INSTALLPATH="`pwd`"
 cd ..
 
 echo "Stopping and unloading service"
-sudo launchctl stop com.teclib.glpi-agent
-sudo launchctl unload /Library/LaunchDaemons/com.teclib.glpi-agent.plist
+MACOS_MAJOR=$(sw_vers -productVersion | cut -d. -f1)
+if [ "${MACOS_MAJOR:-0}" -ge 13 ]; then
+    sudo launchctl bootout system /Library/LaunchDaemons/com.teclib.glpi-agent.plist
+else
+    sudo launchctl stop com.teclib.glpi-agent
+    sudo launchctl unload /Library/LaunchDaemons/com.teclib.glpi-agent.plist
+fi
 
 # Still wait until process has been stopped
 read PID XXX <<<`ps -ec -o pid,command | grep glpi-agent`


### PR DESCRIPTION
Problem
On macOS 13 Ventura and later (tested on macOS 26 Tahoe, Apple Silicon), installing GLPI Agent leaves the service not running. The postinstall script calls launchctl load, which is deprecated and returns Load failed: 5: Input/output error on modern macOS. The same issue affects upgrades via preinstall and uninstalls via uninstaller.sh.

Fix
Replace launchctl load/unload/start with launchctl bootstrap/bootout on macOS 13+. A runtime check on sw_vers selects the right API, keeping backward compatibility with macOS 12 and earlier.

Tested on macOS 26 Tahoe (arm64). (AI-assisted development: Claude)