### PR TITLE
feat: Accept Windows '/?' as --help in scripts

### DIFF
--- a/bin/glpi-agent
+++ b/bin/glpi-agent
@@ -18,6 +18,9 @@ Getopt::Long::Configure( "no_ignorecase" );
 
 my $options = {};
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 unless (GetOptions(
     $options,
     'assetname-support=i',

--- a/bin/glpi-esx
+++ b/bin/glpi-esx
@@ -21,6 +21,9 @@ my $options = {
     path    => '-'
 };
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 unless (GetOptions(
     $options,
     'host=s',

--- a/bin/glpi-injector
+++ b/bin/glpi-injector
@@ -26,6 +26,9 @@ my @failedFiles;
 # Set bundling to support aggregated options. It also make single char options case sensitive.
 Getopt::Long::Configure("bundling");
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 GetOptions(
     $options,
     'help|h',

--- a/bin/glpi-inventory
+++ b/bin/glpi-inventory
@@ -23,6 +23,9 @@ my $options = {
     config => 'none'
 };
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 unless (GetOptions(
     $options,
     'assetname-support=i',

--- a/bin/glpi-netdiscovery
+++ b/bin/glpi-netdiscovery
@@ -23,6 +23,9 @@ our $options = {
     threads => 1
 };
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 unless (GetOptions(
     $options,
     'file=s',

--- a/bin/glpi-netinventory
+++ b/bin/glpi-netinventory
@@ -32,6 +32,9 @@ my $options = {
     threads => 1
 };
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 unless (GetOptions(
     $options,
     'type=s',

--- a/bin/glpi-remote
+++ b/bin/glpi-remote
@@ -35,6 +35,9 @@ my $options = {
     timeout     => 10,
 };
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 GetOptions(
     $options,
     'help|h',

--- a/bin/glpi-wakeonlan
+++ b/bin/glpi-wakeonlan
@@ -19,6 +19,9 @@ my $options = {
     debug => 0,
 };
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 GetOptions(
     $options,
     'mac=s',

--- a/bin/glpi-win32-service
+++ b/bin/glpi-win32-service
@@ -22,6 +22,9 @@ Getopt::Long::Configure( "no_ignorecase" );
 
 my %options = ();
 
+# Support Windows standard help argument /?
+map { $_ = '--help' if $_ eq '/?' } @ARGV;
+
 unless (GetOptions(
     \%options,
     'register',


### PR DESCRIPTION
**Summary**
Windows users typically use `/?` to pull up command-line help. Currently, `Getopt::Long` ignores `/?` since it doesn't use standard dash prefixes. This causes scripts like `glpi-agent.bat` and `glpi-inventory.bat` to launch normally instead of showing the help text.

This PR adds a one-line mapping to map `/?` to `--help` inside the `@ARGV` array for all CLI scripts in the `bin/` directory. Treat the Windows standard help argument '/?' as '--help' in CLI scripts so GetOptions recognizes it. No other behavior changes were made.

**Changes**
- Added `map { $_ = '--help' if $_ eq '/?' } @ARGV;` to the arguments pipeline in all `bin/glpi-*` executables.
- Ensures consistency across the following executables: bin/glpi-agent, bin/glpi-esx, bin/glpi-injector, bin/glpi-inventory, bin/glpi-netdiscovery, bin/glpi-netinventory, bin/glpi-remote, bin/glpi-wakeonlan, and bin/glpi-win32-service. 