### PR TITLE
fix(videos): Exclude Microsoft Remote Display Adapter (RDP) from Windows video inventory

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Win32/Videos.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Win32/Videos.pm
@@ -48,6 +48,9 @@ sub _getVideos {
     )) {
         next unless $object->{Name};
 
+        # Exclude Remote Display Adapter (RDP) across all languages by checking PNPDeviceID
+        next if $object->{PNPDeviceID} && $object->{PNPDeviceID} =~ /REMOTEDISPLAY/i;
+
         my $video = {
             CHIPSET => $object->{VideoProcessor},
             NAME    => $object->{Name},

--- a/t/tasks/inventory/windows/video.t
+++ b/t/tasks/inventory/windows/video.t
@@ -48,10 +48,6 @@ my %tests = (
     ],
     'intel+nvidia' => [
         {
-            CHIPSET     => undef,
-            NAME        => 'Microsoft Remote Display Adapter',
-            RESOLUTION  => '1920x1080',
-        }, {
             CHIPSET     => 'Intel(R) HD Graphics Family',
             MEMORY      => 1024,
             NAME        => 'Intel(R) HD Graphics 4600',


### PR DESCRIPTION
### **Description:**

**What does this PR do?**
This PR updates the Windows video inventory task to explicitly exclude the "Microsoft Remote Display Adapter".

**Why is this needed?**
The Remote Display Adapter is a virtual component that only exists temporarily when an active RDP connection is established to the machine. Without this exclusion, the Components tab in GLPI indexes this temporary adapter, filling the asset's History tab with stale records (constant additions and removals of the video adapter every time a user connects or disconnects via RDP).

**Implementation Details:**
*   **Localization-safe filtering:** The exclusion relies on the adapter's underlying Hardware ID (`PNPDeviceID` matching `REMOTEDISPLAY`) instead of the display name. This ensures the filter remains completely robust across all Windows language versions, as the display name gets translated depending on the OS language pack.
*   **Testing:** We leverage the existing `intel+nvidia` mock dataset, which already contained the WMI data for the "Microsoft Remote Display Adapter". The expected output of the test was updated to ensure the adapter is now successfully and consistently filtered out.