### PR TITLE
fix(QA): Improve Q&A tests on Windows

### DIFF
--- a/t/06pod-listed-categories.t
+++ b/t/06pod-listed-categories.t
@@ -22,7 +22,9 @@ plan(skip_all => 'Data::UUID required')
 plan tests => 2;
 
 my %categories;
-foreach my $line (getAllLines(command => "$^X bin/glpi-agent --list-categories")) {
+my @command = qw(bin/glpi-agent --list-categories);
+unshift @command, $EXECUTABLE_NAME if $OSNAME eq 'MSWin32';
+foreach my $line (getAllLines(command => \@command)) {
     chomp($line);
     next unless $line =~ /^ - (.+)$/;
     $categories{$1} = 1;

--- a/t/06pod-listed-categories.t
+++ b/t/06pod-listed-categories.t
@@ -14,12 +14,15 @@ use constant    LISTED_CATEGORY_COUNT   => 37;
 plan(skip_all => 'Author test, set $ENV{TEST_AUTHOR} to a true value to run')
     if !$ENV{TEST_AUTHOR};
 
+plan(skip_all => 'Data::UUID required')
+    unless Data::UUID->require();
+
 # Check all categtories are listed in glpi-agent pod part
 
 plan tests => 2;
 
 my %categories;
-foreach my $line (getAllLines(command => "bin/glpi-agent --list-categories")) {
+foreach my $line (getAllLines(command => "$^X bin/glpi-agent --list-categories")) {
     chomp($line);
     next unless $line =~ /^ - (.+)$/;
     $categories{$1} = 1;

--- a/t/lib/fake/windows/Win32.pm
+++ b/t/lib/fake/windows/Win32.pm
@@ -3,4 +3,10 @@ package Win32;
 use strict;
 use warnings;
 
+# Fake stub for non-Windows test runs. The version must be declared so that
+# modules which load Win32 indirectly (e.g. via IPC::Cmd -> Win32::IsWinNT)
+# do not fail XSLoader's version check with "version 0 does not match".
+# 0.27 is the minimum required by the strictest consumer in the dependency chain.
+our $VERSION = 0.27;
+
 1;


### PR DESCRIPTION
Running `make test TEST_AUTHOR=1 TEST_FILES="t/02critic.t t/03var.t t/04pod-syntax.t t/06pod-spelling.t t/06pod-listed-categories.t t/07whitespaces.t t/09cpanmeta.t"` on Windows may fail if `Data::UUID` isn't installed and per `Win32` dependencies check.