### PR TITLE
Revert "fix(videos): fallback to pci.ids database for generic video drivers on Windows"

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Win32/Videos.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Win32/Videos.pm
@@ -6,7 +6,6 @@ use warnings;
 use parent 'GLPI::Agent::Task::Inventory::Module';
 
 use GLPI::Agent::Tools;
-use GLPI::Agent::Tools::Generic;
 use GLPI::Agent::Tools::Win32;
 
 use constant    category    => "video";
@@ -81,9 +80,6 @@ sub _getVideos {
         }
 
         my $pnpdeviceid = _pnpdeviceid($object->{PNPDeviceID});
-
-        my $found_specific_driver = 0;
-
         if ($pnpdeviceid) {
             # Try to get memory from registry
             my $videokey = getRegistryKey(
@@ -98,8 +94,6 @@ sub _getVideos {
                     my $thispnpdeviceid = _pnpdeviceid($videokey->{$subkey}->{"/MatchingDeviceId"})
                         or next;
                     next unless $thispnpdeviceid eq $pnpdeviceid;
-                    $found_specific_driver = 1;
-
                     if (defined($videokey->{$subkey}->{"/HardwareInformation.qwMemorySize"})) {
                         my $memorysize = $videokey->{$subkey}->{"/HardwareInformation.qwMemorySize"} =~ /^\d+$/ ?
                             int($videokey->{$subkey}->{"/HardwareInformation.qwMemorySize"})
@@ -115,35 +109,6 @@ sub _getVideos {
                         $video->{MEMORY} = $memorysize if $memorysize && $memorysize > 0;
                         last;
                     }
-                }
-            }
-        }
-
-        # Fallback for generic drivers (e.g. Microsoft Basic Display Adapter)
-        # If no specific registry key was found matching the PNPDeviceID, it means a generic driver is in use.
-        if (!$found_specific_driver && !empty($object->{PNPDeviceID})) {
-            if ($object->{PNPDeviceID} =~ /PCI\\VEN_(\S{4})&DEV_(\S{4})/i) {
-                my $vendor_id = lc($1);
-                my $device_id = lc($2);
-                my $vendor = getPCIDeviceVendor(id => $vendor_id, %params);
-                if ($vendor && $vendor->{devices}->{$device_id}) {
-                    my $device_name = $vendor->{devices}->{$device_id}->{name} // '';
-                    my $vendor_name = $vendor->{name} // '';
-                    my ($pci_name, $pci_chipset);
-                    if ($device_name =~ /^(.*)\s+\[(.*)\]$/) {
-                        $pci_name = $1;
-                        $pci_chipset = $2;
-                    }
-                    if ($object->{PNPDeviceID} =~ /SUBSYS_\S{4}(\S{4})/i) {
-                        my $subvendor_id = lc($1);
-                        if ($subvendor_id ne '0000') {
-                            my $subvendor = getPCIDeviceVendor(id => $subvendor_id, %params);
-                            my $manufacturer = $subvendor ? $subvendor->{name} : '';
-                            $pci_name = $manufacturer.' '.$pci_name if $manufacturer && $pci_name;
-                        }
-                    }
-                    $video->{CHIPSET} = $pci_chipset || $device_name;
-                    $video->{NAME}    = $pci_name || $vendor_name;
                 }
             }
         }

--- a/t/tasks/inventory/windows/video.t
+++ b/t/tasks/inventory/windows/video.t
@@ -40,8 +40,8 @@ my %tests = (
     ],
     'microsoft-basic-display' => [
         {
-            CHIPSET     => 'UHD Graphics 600',
-            NAME        => 'GeminiLake',
+            CHIPSET     => 'Intel(R) BXT Mobile/Desktop Gra',
+            NAME        => 'Adaptador de Vídeo Básico da Microsoft',
             PCISLOT     => '00:02.0',
             RESOLUTION  => '1920x1080',
         }


### PR DESCRIPTION
### Description
Reverts commit feb411f9c6e58e02d5e729f21346bf5d0678bede.

### Reason for Revert
Overriding the video card name in the agent breaks the current GLPI core implementation for graphic cards ([GraphicCard.php](https://github.com/glpi-project/glpi/blob/874bff83318eb33c9d7e790124a6403eacc371ae/src/Glpi/Inventory/Asset/GraphicCard.php)), which relies on matching the name with the controller.

### Context & Future Fix
The matching logic is currently being refactored in GLPI core to match via the `TYPE` (driver) rather than the name. This is being addressed in glpi-project/glpi#24494. 

Reverting this agent-side commit prevents inventory breakage in the current GLPI releases until the core refactoring is merged and available.