### PR TITLE
fix(storage): allow NVMe and RAID as valid storage interfaces

### DIFF
--- a/lib/GLPI/Agent/Inventory.pm
+++ b/lib/GLPI/Agent/Inventory.pm
@@ -116,7 +116,7 @@ my %checks = (
         INTERFACE => {
             # Check can be ignored since GLPI 10.0.4
             not_since   => glpiVersion('10.0.4'),
-            regexp      => qr/^(SCSI|HDC|IDE|USB|1394|SATA|SAS|ATAPI)$/
+            regexp      => qr/^(SCSI|HDC|IDE|USB|1394|SATA|SAS|ATAPI|NVME|RAID)$/i
         }
     },
     VIRTUALMACHINES => {


### PR DESCRIPTION
### Description of the change

This PR adds `NVMe` and `RAID` to the list of allowed values for the `INTERFACE` field within the `STORAGES` section, and makes the validation regex case-insensitive.

**The Problem:**
When running the agent with debugging enabled (e.g., `glpi-agent --force --full --logger=stderr --debug`), it produces the following warning:
`[debug] invalid value NVMe for field INTERFACE for section STORAGES`
This occurs because the `Win32::Storages` task outputs the interface as `NVMe`, and `MacOS::Storages` outputs it as `NVME`, but neither was included in the strict whitelist array inside `GLPI::Agent::Inventory`. The `RAID` interface was also missing from this validation list despite being a valid return value.
While GLPI-Agent natively bypasses this strict validation when it detects it's communicating with a GLPI server version >= 10.0.4 (which dynamically accepts unknown interfaces), this version negotiation hasn't happened during a local/offline inventory execution. As a result, the agent falls back to its default, strict validation rules and flags these modern, valid interfaces as errors in the debug logs.

**The Solution:**
* Added `NVME` and `RAID` to the validation regex in `lib/GLPI/Agent/Inventory.pm`.
* Appended the `/i` flag to make the regex case-insensitive. This securely supports both the `NVMe` format generated by Windows and the `NVME` format generated by MacOS/Linux without conflict.

### Impact
* Eliminates the false-positive invalid value debug warnings during inventory.
* Prevents these legitimate storage interfaces from being prematurely filtered out when the agent sends inventory data to GLPI versions older than 10.0.4. While older GLPI servers (pre-10.0.4) will still quietly drop the unknown `INTERFACE` string, the storage drive will still be successfully imported into the inventory with all its other properties (size, model, serial, etc.), leaving only the interface field blank on the server side.