### PR TITLE
Feature: snmp get bulk support configuration

### DIFF
--- a/etc/snmp-advanced-support.cfg
+++ b/etc/snmp-advanced-support.cfg
@@ -9,6 +9,11 @@
 # uncomment the following line:
 #oids = .1.3.6.1.2.1.1.1.0,.1.3.6.1.2.1.7526.2.4
 
+# "maxrepetitions" is the default value for -maxrepetitions Net::SNMP get_table() parameter.
+# If set to 0, Net::SNMP will always try to use get-bulk-requests. If a device doesn't support this
+# kind of request, this option must be kept to 1 or it won't be supported.
+#maxrepetitions = 1
+
 # You should create and define you specific parameter in the following included configuration file
 # to override any default.
 include "snmp-advanced-support.local"

--- a/etc/snmp-advanced-support.cfg
+++ b/etc/snmp-advanced-support.cfg
@@ -14,6 +14,14 @@
 # kind of request, this option must be kept to 1 or it won't be supported.
 #maxrepetitions = 1
 
+# By default, we try to discover if a device supports bulk requests but this can be disabled if that
+# check makes trouble.
+#skip-bulk-support-discovery = 0
+
+# By default, when checking if a device supports get-bulk-request, we do it on mib-2.system
+# "bulk-support-discovery-oid" can be defined to another numeric oid if mib-2.system is not correct.
+#bulk-support-discovery-oid = .1.3.6.1.2.1.1
+
 # You should create and define you specific parameter in the following included configuration file
 # to override any default.
 include "snmp-advanced-support.local"

--- a/lib/GLPI/Agent/SNMP/Live.pm
+++ b/lib/GLPI/Agent/SNMP/Live.pm
@@ -28,6 +28,10 @@ my $defaults = {
     # and only one has to respond to validate session. If none provides any answer, this means there's
     # no device or the device is not reachable
     oids    => '.1.3.6.1.2.1.1.1.0',
+    # maxrepetitions is the default value for -maxrepetitions Net::SNMP get_table() parameter during our
+    # walk() api call. If set to 0, Net::SNMP will always try to use get-bulk-requests. If a device
+    # doesn't support this kind of request, this option must be kept to 1 or it won't be supported.
+    maxrepetitions  => 1,
 };
 
 sub new {
@@ -66,6 +70,15 @@ sub new {
         die "invalid 'oids' configuration in $snmp_advanced_support_cfg\n"
             if $oids ne $defaults->{oids} && scalar(grep { /^\.(?:\d+\.)+\d+$/ } @oids) != scalar(@oids);
         $config->{oids} = \@oids;
+
+        # Check values which must be a positive integer
+        foreach my $key (qw(maxrepetitions)) {
+            if (empty($config->{$key}) || $config->{$key} !~ /^\d+$/) {
+                $config->{$key} = $defaults->{$key};
+            } else {
+                $config->{$key} = int($config->{$key});
+            }
+        }
 
         # Reload config not before one minute
         $config_load_timeout = time + 60;
@@ -212,7 +225,8 @@ sub walk {
     my $session = $self->{vlan_session} // $self->{session};
     my %options = (-baseoid => $oid);
     $options{'-contextname'}    = $self->{context} if defined($self->{context});
-    $options{'-maxrepetitions'} = 1                if $session->version() != SNMP_VERSION_1;
+    $options{'-maxrepetitions'} = $config->{maxrepetitions}
+        if $session->version() != SNMP_VERSION_1 && $config->{maxrepetitions};
 
     my $response = $session->get_table(%options);
 

--- a/lib/GLPI/Agent/SNMP/Live.pm
+++ b/lib/GLPI/Agent/SNMP/Live.pm
@@ -32,6 +32,11 @@ my $defaults = {
     # walk() api call. If set to 0, Net::SNMP will always try to use get-bulk-requests. If a device
     # doesn't support this kind of request, this option must be kept to 1 or it won't be supported.
     maxrepetitions  => 1,
+    # By default, we try to discover if a device supports bulk requests but this can be disabled if that
+    # check makes trouble.
+    "skip-bulk-support-discovery" => 0,
+    # By default, we test on mib-2.system if a device supports bulk requests
+    "bulk-support-discovery-oid" => '.1.3.6.1.2.1.1',
 };
 
 sub new {
@@ -72,7 +77,7 @@ sub new {
         $config->{oids} = \@oids;
 
         # Check values which must be a positive integer
-        foreach my $key (qw(maxrepetitions)) {
+        foreach my $key (qw(maxrepetitions skip-bulk-support-discovery)) {
             if (empty($config->{$key}) || $config->{$key} !~ /^\d+$/) {
                 $config->{$key} = $defaults->{$key};
             } else {
@@ -80,9 +85,19 @@ sub new {
             }
         }
 
+        # Check bulk-support-discovery-oid is an oid if set
+        unless (empty($config->{"bulk-support-discovery-oid"})) {
+            delete $config->{"bulk-support-discovery-oid"}
+                unless $config->{"bulk-support-discovery-oid"} =~ /^\.(?:\d+\.)+\d+$/;
+        }
+
         # Reload config not before one minute
         $config_load_timeout = time + 60;
     }
+
+    # Prepare for get-bulk-request support check
+    $self->{bulk_support} = 1
+        unless $version eq "snmpv1" || $config->{"skip-bulk-support-discovery"};
 
     # shared options
     my %options = (
@@ -140,6 +155,18 @@ sub testSession {
 
     my $version_id = $self->{session}->version();
     die "no version set on snmp session\n" unless defined($version_id);
+
+    # Test if get-bulk-request is supported to enhance walk() api performance.
+    # But we need to run the test only if maxrepetitions is set to 1 which is the default.
+    # Also if we get an answer if means the session is established so we can return earlier.
+    if ($version_id != SNMP_VERSION_1 && $self->{bulk_support} && $config->{maxrepetitions} == 1) {
+        # Try to get 2 entries using walk api on configured oid or on mib-2.system
+        my $test = $self->walk($config->{"bulk-support-discovery-oid"} // $defaults->{"bulk-support-discovery-oid"}, 5);
+        # Bulk support and session are validated if we got expected entries;
+        return if $test;
+        # Finally disable bulk support for this device if test failed
+        delete $self->{bulk_support};
+    }
 
     # No need to test SNMPv3 session as still established
     return if $version_id == SNMP_VERSION_3;
@@ -218,19 +245,27 @@ sub get {
 }
 
 sub walk {
-    my ($self, $oid) = @_;
+    my ($self, $oid, $check) = @_;
 
     return unless $oid;
+
+    my $maxrepetitions = $check // $config->{maxrepetitions};
 
     my $session = $self->{vlan_session} // $self->{session};
     my %options = (-baseoid => $oid);
     $options{'-contextname'}    = $self->{context} if defined($self->{context});
-    $options{'-maxrepetitions'} = $config->{maxrepetitions}
-        if $session->version() != SNMP_VERSION_1 && $config->{maxrepetitions};
+    $options{'-maxrepetitions'} = $maxrepetitions
+        if $session->version() != SNMP_VERSION_1 && $maxrepetitions &&
+            # But set maxrepetitions only if forced or if test on the device failed
+            ($maxrepetitions > 1 || !$self->{bulk_support});
 
     my $response = $session->get_table(%options);
 
-    return unless $response;
+    return unless ref($response) eq 'HASH';
+
+    # Still return quickly when only testing if get-bulk-request is supported
+    return scalar(keys(%{$response})) > 1 ? 1 : 0
+        if $check;
 
     my $values;
     my $offset = length($oid) + 1;


### PR DESCRIPTION
Permits to set values in `etc/snmp-advanced-support.cfg`:
 1. To force `maxrepetitions` to `0` to leave Net::SNMP the choice to use get-bulk-request with the best value. The usual value is `25`.
 2. To force `maxrepetitions` to be set to any positive value.
 3. When default of `1` is kept, for each device: glpi-agent will try to run a request with `maxrepetitions` set to `2` as minimum, then
    1. If the try returns more than one value, we will continue to use get-bulk-request setting `max-repetitions` to `0` for the device,
    2. Otherwise, `maxrepetitions` is kept as `1` for the device.
4. To disable bulk support discovery on devices, `skip-bulk-support-discovery` can be set to `1`. It defaults to `0`.
5. The discovery is done on `mib-2.system` oid which should be supported by most devices. Another oid can be set by setting `bulk-support-discovery-oid`. It defaults to `.1.3.6.1.2.1.1`.