### PR TITLE
Disable getaddrinfo native support in perl on macosx

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,6 +31,7 @@ packaging:
   - gcc 16.2.0posix-14.0.0-msvcrt-r1
   - OpenSSL 3.5.8
 * Update MacOSX packages to use OpenSSL 3.5.8
+  - disable getaddrinfo native support in perl to avoid crash on tahoe
 
 1.19 Tue, 04 Aug 2026
 

--- a/contrib/macosx/glpi-agent-packaging.sh
+++ b/contrib/macosx/glpi-agent-packaging.sh
@@ -186,17 +186,9 @@ build_perl () {
         fi
     fi
 
-    PATCHPERL_URL="https://raw.githubusercontent.com/gugod/patchperl-packing/master/patchperl"
-    [ -e patchperl ] || curl -so patchperl  "$PATCHPERL_URL"
     cd build
     [ -d "perl-$PERL_VERSION" ] || tar xzf "../$PERL_ARCHIVE"
     cd "perl-$PERL_VERSION"
-    if [ ! -e patchperl ]; then
-        cp -a ../../patchperl .
-        chmod +x patchperl
-        chmod -R +w .
-        ./patchperl
-    fi
     if [ ! -e Makefile ]; then
         rm -f config.sh Policy.sh
         ./Configure -de -Dprefix=$BUILD_PREFIX -Duserelocatableinc -DNDEBUG    \

--- a/contrib/macosx/glpi-agent-packaging.sh
+++ b/contrib/macosx/glpi-agent-packaging.sh
@@ -186,6 +186,9 @@ build_perl () {
         fi
     fi
 
+    # Disable getaddrinfo native support on MacOSX, perl will use an emulated version from Socket module
+    BUILD_NO_GETADDRINFO="-Dd_getaddrinfo=undef -Dd_gai_strerror=undef -Dd_getnameinfo=undef"
+
     cd build
     [ -d "perl-$PERL_VERSION" ] || tar xzf "../$PERL_ARCHIVE"
     cd "perl-$PERL_VERSION"
@@ -194,6 +197,7 @@ build_perl () {
         ./Configure -de -Dprefix=$BUILD_PREFIX -Duserelocatableinc -DNDEBUG    \
             -Dman1dir=none -Dman3dir=none -Dusethreads -UDEBUGGING             \
             -Dusemultiplicity -Duse64bitint -Darch=$ARCH                       \
+            $BUILD_NO_GETADDRINFO                                              \
             -Aeval:privlib=.../../lib -Aeval:scriptdir=.../../bin              \
             -Aeval:vendorprefix=.../.. -Aeval:vendorlib=.../../agent           \
             -Accflags="$SDKFLAGS $EXTRA_PERL_CCFLAGS"                          \


### PR DESCRIPTION
Also remove patchperl support which is not really useful.

Disabling getaddrinfo native support in perl on macosx is intended to fix the last issue reported in #1041 